### PR TITLE
Improve exercise loading

### DIFF
--- a/src/core/LessonManager.js
+++ b/src/core/LessonManager.js
@@ -123,8 +123,8 @@ export class LessonManager {
       // Charger les fichiers de l'exercice
       const files = {};
       
-      // Charger les fichiers principaux
-      for (const filename of exercise.files) {
+      // Charger les fichiers principaux en parallèle
+      const fetchPromises = exercise.files.map(async (filename) => {
         const filePath = `${exercise.basePath}${filename}`;
         try {
           const response = await fetch(filePath);
@@ -134,7 +134,9 @@ export class LessonManager {
         } catch (error) {
           console.warn(`Impossible de charger ${filename}:`, error);
         }
-      }
+      });
+
+      await Promise.all(fetchPromises);
       
       // Préparer les données de l'exercice
       this.currentExercise = {


### PR DESCRIPTION
## Summary
- parallelize file loading for lesson exercises

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b34d133c483209ed79668a6fe2892