### PR TITLE
Use worker for JS execution

### DIFF
--- a/src/modules/javascript/executor.worker.js
+++ b/src/modules/javascript/executor.worker.js
@@ -1,52 +1,52 @@
 // src/modules/javascript/executor.worker.js
 self.addEventListener('message', async (event) => {
-  const { id, code, options } = event.data;
+  const { id, code, options = {} } = event.data;
   const logs = [];
-  let error = null;
-  
-  // Capturer console.log
-  const originalLog = console.log;
-  console.log = (...args) => {
-    logs.push({
-      type: 'log',
-      timestamp: Date.now(),
-      args: args.map(arg => {
-        try {
-          return JSON.stringify(arg);
-        } catch {
-          return String(arg);
-        }
-      })
-    });
+  const errors = [];
+
+  const originalConsole = {
+    log: console.log,
+    error: console.error,
+    warn: console.warn,
+    info: console.info
   };
-  
+
+  const capture = (type) => (...args) => {
+    logs.push({ type, args });
+  };
+
+  console.log = capture('log');
+  console.error = capture('error');
+  console.warn = capture('warn');
+  console.info = capture('info');
+
+  let success = true;
+
   try {
-    // Créer une fonction isolée
-    const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
-    const userFunction = new AsyncFunction(code);
-    
-    // Exécuter avec timeout
-    const timeoutPromise = new Promise((_, reject) => {
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+    const fn = new AsyncFunction(code);
+    const timeout = new Promise((_, reject) => {
       setTimeout(() => reject(new Error('Timeout')), options.timeout || 5000);
     });
-    
-    await Promise.race([userFunction(), timeoutPromise]);
+
+    await Promise.race([fn(), timeout]);
   } catch (err) {
-    error = {
+    success = false;
+    errors.push({
       message: err.message,
       stack: err.stack,
-      line: err.line
-    };
+      line: err.lineNumber || err.line || null
+    });
   } finally {
-    console.log = originalLog;
+    console.log = originalConsole.log;
+    console.error = originalConsole.error;
+    console.warn = originalConsole.warn;
+    console.info = originalConsole.info;
   }
-  
-  self.postMessage({
-    id,
-    result: {
-      logs,
-      error,
-      success: !error
-    }
-  });
+
+  self.postMessage({ id, logs, errors, success });
+
+  if (options.terminate) {
+    self.close();
+  }
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,10 +21,13 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          'monaco': ['monaco-editor'],
-          'vendor': ['localforage', 'eventemitter3']
+          monaco: ['monaco-editor'],
+          vendor: ['localforage', 'eventemitter3']
         }
       }
     }
+  },
+  worker: {
+    format: 'es'
   }
 });


### PR DESCRIPTION
## Summary
- create a web worker in `JavaScriptModule` and send user code to execute
- capture logs and errors from the worker
- update worker script to emit structured results and optionally terminate
- configure Vite to bundle the worker as an ES module

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b34dd79f8832097e990afe8fd053e