### PR TITLE
Add course selector container to UI

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -20,6 +20,7 @@ export class UIManager {
       console: document.getElementById('console'),
       lessonsList: document.getElementById('lessons-list'),
       lessonInfo: document.getElementById('lesson-info'),
+      courseSelector: document.getElementById('course-selector'),
       moduleSelector: document.getElementById('module-selector'),
       runButton: document.getElementById('btn-run'),
       resetButton: document.getElementById('btn-reset'),
@@ -73,6 +74,7 @@ this.setupOutputTabs();
           <span class="header-tagline">Apprends à programmer</span>
         </div>
         <nav class="header-nav">
+          <div id="course-selector" class="course-selector"></div>
           <div class="module-selector" id="module-selector"></div>
           <button class="btn-icon" id="btn-settings" title="Paramètres">⚙️</button>
         </nav>


### PR DESCRIPTION
## Summary
- add `course-selector` element inside navigation bar
- register course selector DOM element in UI initialization
- build project to ensure integrity

## Testing
- `npm run build`
- `npm test` *(fails: No test files found)*
- `npm run dev -- --port 5173`

------
https://chatgpt.com/codex/tasks/task_e_684c740d4c048320ae3d36a5aff25cac