### PR TITLE
Refactor lesson metadata

### DIFF
--- a/public/lessons/html-css/manifest.json
+++ b/public/lessons/html-css/manifest.json
@@ -29,7 +29,7 @@
           "mainFile": "script.js",
           "htmlFile": "index.html",
           "testFile": "test.js",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "02-restaurant-page",
@@ -39,7 +39,7 @@
           "files": ["README.md", "index.html", "solution.html", "bonus.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "03-blog-article",
@@ -49,7 +49,7 @@
           "files": ["README.md", "index.html", "solution.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "04-text-correction",
@@ -59,7 +59,7 @@
           "files": ["README.md", "index.html", "solution.html", "hints.md", "erreurs.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         }
       ]
     },
@@ -79,7 +79,7 @@
           "files": ["README.md", "index.html", "solution.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "02-travel-guide",
@@ -89,7 +89,7 @@
           "files": ["README.md", "index.html", "solution.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "03-restaurant-menu",
@@ -99,7 +99,7 @@
           "files": ["README.md", "index.html", "solution.html", "bonus.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         }
       ]
     },
@@ -119,7 +119,7 @@
           "files": ["README.md", "index.html", "solution.html", "advanced.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "02-color-palette",
@@ -130,7 +130,7 @@
           "mainFile": "script.js",
           "htmlFile": "index.html",
           "testFile": "test.js",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "03-typography-poster",
@@ -140,7 +140,7 @@
           "files": ["README.md", "index.html", "collection.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         }
       ]
     },
@@ -160,7 +160,7 @@
           "files": ["README.md", "index.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "02-photo-gallery",
@@ -170,7 +170,7 @@
           "files": ["README.md", "index.html", "solution.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         }
       ]
     },
@@ -190,7 +190,7 @@
           "files": ["README.md", "index.html", "solution.html", "hints.md"],
           "mainFile": "script.js",
           "htmlFile": "index.html",
-          "type": "web"
+          "language": "web"
         }
       ]
     }

--- a/public/lessons/javascript/manifest.json
+++ b/public/lessons/javascript/manifest.json
@@ -28,7 +28,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         },
         {
           "id": "02-variables",
@@ -38,7 +38,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         },
         {
           "id": "03-calculator",
@@ -48,7 +48,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         }
       ]
     },
@@ -68,7 +68,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         },
         {
           "id": "02-multiplication-table",
@@ -78,7 +78,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         }
       ]
     },
@@ -98,7 +98,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         },
         {
           "id": "02-arrow-functions",
@@ -108,7 +108,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         }
       ]
     },
@@ -128,7 +128,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         },
         {
           "id": "02-student-grades",
@@ -138,7 +138,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         }
       ]
     },
@@ -158,7 +158,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         },
         {
           "id": "02-bank-account",
@@ -168,7 +168,7 @@
           "files": ["README.md", "index.js", "solution.js", "test.js"],
           "mainFile": "index.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         }
       ]
     },
@@ -189,7 +189,7 @@
           "mainFile": "script.js",
           "htmlFile": "index.html",
           "testFile": "test.js",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "02-todo-app",
@@ -200,7 +200,7 @@
           "mainFile": "script.js",
           "htmlFile": "index.html",
           "testFile": "test.js",
-          "type": "web"
+          "language": "web"
         }
       ]
     },
@@ -221,7 +221,7 @@
           "mainFile": "script.js",
           "htmlFile": "index.html",
           "testFile": "test.js",
-          "type": "web"
+          "language": "web"
         },
         {
           "id": "02-api-simulator",
@@ -231,7 +231,7 @@
           "files": ["README.md", "script.js", "solution.js", "test.js"],
           "mainFile": "script.js",
           "testFile": "test.js",
-          "type": "coding"
+          "language": "js"
         },
         {
           "id": "03-weather-app",
@@ -242,7 +242,7 @@
           "mainFile": "script.js",
           "htmlFile": "index.html",
           "testFile": "test.js",
-          "type": "web"
+          "language": "web"
         }
       ]
     },
@@ -263,7 +263,7 @@
           "mainFile": "main.js",
           "moduleFiles": ["livre.js", "bibliotheque.js", "utilisateur.js"],
           "testFile": "test.js",
-          "type": "modules"
+          "language": "modules"
         }
       ]
     }

--- a/src/core/LessonManager.js
+++ b/src/core/LessonManager.js
@@ -103,7 +103,7 @@ export class LessonManager {
           <div class="exercise-info">
             <h4>${exercise.title}</h4>
             <p>${exercise.description}</p>
-            <span class="exercise-meta">${exercise.difficulty} • ${exercise.type}</span>
+            <span class="exercise-meta">${exercise.difficulty} • ${exercise.language}</span>
           </div>
         `;
         
@@ -188,11 +188,11 @@ async loadCourse(course) {
       this.displayExercise();
       
       // Activer le bon module
-      const moduleType = exercise.type === 'web' ? 'web' : 'javascript';
+      const moduleType = exercise.language === 'web' ? 'web' : 'javascript';
       await this.app.modules.activateModule(moduleType);
       
       // Si c'est un exercice web, charger aussi le HTML
-      if (exercise.type === 'web' && exercise.htmlFile) {
+      if (exercise.language === 'web' && exercise.htmlFile) {
         const webModule = this.app.modules.getActiveModule();
         if (webModule && webModule.id === 'web') {
           webModule.files.set('index.html', { 

--- a/src/core/ModuleManager.js
+++ b/src/core/ModuleManager.js
@@ -78,8 +78,10 @@ export class ModuleManager extends EventEmitter {
     const config = await module.getEditorConfig();
     this.app.ui.editor.setLanguage(config.language);
     
-    // Mettre à jour l'interface
-    this.app.ui.setActiveModule(moduleId);
+    // Mettre à jour l'interface si nécessaire
+    if (typeof this.app.ui.setActiveModule === 'function') {
+      this.app.ui.setActiveModule(moduleId);
+    }
     
     // Sauvegarder le choix
     await this.app.saveSession();

--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -21,7 +21,6 @@ export class UIManager {
       lessonsList: document.getElementById('lessons-list'),
       lessonInfo: document.getElementById('lesson-info'),
       courseSelector: document.getElementById('course-selector'),
-      moduleSelector: document.getElementById('module-selector'),
       runButton: document.getElementById('btn-run'),
       resetButton: document.getElementById('btn-reset'),
       progressFill: document.getElementById('progress-fill')
@@ -50,8 +49,6 @@ this.setupOutputTabs();
       // Configurer les événements
       this.setupEventListeners();
       
-      // Initialiser le sélecteur de modules
-      this.initModuleSelector();
       
     } catch (error) {
       console.error('Failed to initialize UI components:', error);
@@ -75,7 +72,6 @@ this.setupOutputTabs();
         </div>
         <nav class="header-nav">
           <div id="course-selector" class="course-selector"></div>
-          <div class="module-selector" id="module-selector"></div>
           <button class="btn-icon" id="btn-settings" title="Paramètres">⚙️</button>
         </nav>
       </header>
@@ -222,39 +218,6 @@ this.setupOutputTabs();
     }
   }
   
-  initModuleSelector() {
-    // Créer le sélecteur de modules
-    const selector = document.createElement('select');
-    selector.className = 'module-select';
-    
-    // Écouter les modules chargés
-    this.app.modules.on('modules:loaded', (modules) => {
-      selector.innerHTML = modules.map(module => `
-        <option value="${module.id}">
-          ${module.icon} ${module.name}
-        </option>
-      `).join('');
-      
-      // Sélectionner le module actif
-      if (this.app.currentModule) {
-        selector.value = this.app.currentModule.id;
-      }
-    });
-    
-    // Gérer le changement de module
-    selector.addEventListener('change', (e) => {
-      this.app.modules.activateModule(e.target.value);
-    });
-    
-    this.elements.moduleSelector.appendChild(selector);
-  }
-  
-  setActiveModule(moduleId) {
-    const selector = this.elements.moduleSelector.querySelector('select');
-    if (selector) {
-      selector.value = moduleId;
-    }
-  }
   
   showLesson(lesson) {
     if (!lesson) {

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,6 @@
       </div>
       <nav class="header-nav">
           <div id="course-selector" class="course-selector"></div>
-        <div class="module-selector" id="module-selector"></div>
         <button class="btn-icon" id="btn-settings" title="Paramètres">⚙️</button>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- rename `type` to `language` for each exercise
- change `coding` values to `js`
- adapt lesson manager to use `language` for module selection
- remove obsolete module selector from the UI

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c788808fc83209fa7c67520fcb1a0