### PR TITLE
Expose per-test results in UI

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -188,11 +188,21 @@ this.setupOutputTabs();
       
       // Vérifier si l'exercice est réussi
       if (this.app.currentLesson) {
-        const success = await this.app.lessons.checkExercise(
+        const { success, tests } = await this.app.lessons.checkExercise(
           code,
           result
         );
-        
+
+        if (Array.isArray(tests)) {
+          tests.forEach(t => {
+            if (t.pass) {
+              this.console.log(`✅ ${t.name}`);
+            } else {
+              this.console.error(`❌ ${t.name}`);
+            }
+          });
+        }
+
         if (success) {
           this.showSuccess('Exercice réussi ! 🎉');
           this.app.lessons.completeExercise(this.app.currentLesson.fullId);


### PR DESCRIPTION
## Summary
- improve `checkExercise` to run first test function and return detailed results
- show pass/fail for each test in the console

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2242b93c8320ae1c9c4d380199d5