### PR TITLE
Add TestRunner component styles

### DIFF
--- a/src/components/TestRunner/TestRunner.js
+++ b/src/components/TestRunner/TestRunner.js
@@ -1,0 +1,30 @@
+export class TestRunner {
+  constructor(container) {
+    this.container = container;
+    this.results = [];
+    this.render();
+  }
+
+  render() {
+    this.container.innerHTML = `<ul class="test-result-list"></ul>`;
+    this.listEl = this.container.querySelector('.test-result-list');
+  }
+
+  showResults(results = []) {
+    this.results = results;
+    if (!this.listEl) this.render();
+    this.listEl.innerHTML = '';
+    results.forEach(r => {
+      const li = document.createElement('li');
+      li.className = `test-result ${r.pass ? 'pass' : 'fail'}`;
+      li.textContent = r.name;
+      this.listEl.appendChild(li);
+    });
+  }
+
+  clear() {
+    if (this.listEl) {
+      this.listEl.innerHTML = '';
+    }
+  }
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -669,3 +669,31 @@ body {
   font-family: 'Consolas', 'Monaco', monospace;
 }
 
+/* Test Runner */
+.test-result-list {
+  list-style: none;
+  padding: 10px;
+  font-family: 'Consolas', 'Monaco', monospace;
+  font-size: 14px;
+}
+
+.test-result {
+  margin-bottom: 4px;
+}
+
+.test-result.pass {
+  color: var(--color-success);
+}
+
+.test-result.fail {
+  color: var(--color-danger);
+}
+
+.test-result.pass::before {
+  content: '✅ ';
+}
+
+.test-result.fail::before {
+  content: '❌ ';
+}
+


### PR DESCRIPTION
## Summary
- style test result list with pass/fail cues
- add `TestRunner` component for showing test results

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d2763fb9083208303004ffa6535dc