### PR TITLE
Fix scroll overflow for lesson info

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -303,9 +303,16 @@ body {
   }
 }
 
+
 .lesson-info,
 .console-entry {
   animation: fadeIn 0.3s ease;
+}
+
+/* Lesson Info */
+.lesson-info {
+  overflow-y: auto;
+  padding: 20px;
 }
 
 /* File Tabs */


### PR DESCRIPTION
## Summary
- make lesson info panel scrollable

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684d680d549483208422d99340980749