### PR TITLE
Remove duplicate saveProgress implementation

### DIFF
--- a/src/core/LessonManager.js
+++ b/src/core/LessonManager.js
@@ -367,12 +367,6 @@ ${exercise.difficulty}
     }
   }
   
-  async saveProgress() {
-    await this.app.storage.set('completedExercises', Array.from(this.completedExercises));
-    await this.app.storage.set('lastCompletedDate', new Date().toISOString());
-    await this.app.storage.set('currentPath', this.manifest.name);
-  }
-  
   async loadProgress() {
     const saved = await this.app.storage.get('completedExercises');
     if (saved) {


### PR DESCRIPTION
## Summary
- remove redundant `saveProgress` method from LessonManager
- keep single course-aware `saveProgress`

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684d71bcb61c83208070ea8b47337ee9