### PR TITLE
Fix relative course URL resolution

### DIFF
--- a/src/core/CourseManager.js
+++ b/src/core/CourseManager.js
@@ -122,9 +122,10 @@ export class CourseManager {
     if (url.startsWith('http://') || url.startsWith('https://')) {
       return url;
     }
-    
+
     // Sinon, la résoudre par rapport au chemin de base
-    return new URL(url, import.meta.env.BASE_URL + 'lessons/').href;
+    const base = new URL(import.meta.env.BASE_URL + 'lessons/', window.location.origin);
+    return new URL(url, base).href;
   }
   
   updateCourseUI() {


### PR DESCRIPTION
## Summary
- fix the `resolveUrl` function so relative course manifests resolve from the app origin

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684dab3b06808320a5cbc302c3c76f34