### PR TITLE
Fix monaco worker path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite';
 import monacoEditor from 'vite-plugin-monaco-editor';
 const monacoEditorPlugin = monacoEditor.default;
-import { resolve } from 'path';
+import { resolve, join } from 'path';
 
 export default defineConfig({
   plugins: [
-    monacoEditorPlugin({})
+    monacoEditorPlugin({
+      customDistPath: (root, outDir) => join(root, outDir, 'monacoeditorwork')
+    })
   ],
   // Use a relative base path in production that matches the repository name
   base: process.env.NODE_ENV === 'production' ? '/stage2nd/' : '/',


### PR DESCRIPTION
## Summary
- configure vite monaco plugin to write workers under `dist/monacoeditorwork`

## Testing
- `npm ci`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684db16c7a5c8320ad3cfce89dd0de36