### PR TITLE
Improve chat auto-connect

### DIFF
--- a/src/components/ChatWidget/ChatWidget.js
+++ b/src/components/ChatWidget/ChatWidget.js
@@ -6,7 +6,12 @@ export class ChatWidget {
     this.service = new ChatService();
     this.messagesEl = null;
     this.inputEl = null;
+    this.id = this.generateId();
     this.render();
+    this.register(this.id);
+    window.addEventListener('beforeunload', () => {
+      this.service.sendMessage(`${this.id} a quitté le chat`);
+    });
   }
 
   render() {
@@ -26,9 +31,17 @@ export class ChatWidget {
       .addEventListener('click', () => this.handleSend());
   }
 
+  generateId() {
+    return `user-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
   async register(username) {
     this.service.register(username);
     this.service.onMessage(msg => this.addMessage(msg));
+    this.service.on('open', () => {
+      this.service.sendMessage(`${username} a rejoint le chat`);
+      this.addSystemMessage(`Connecté en tant que ${username}`);
+    });
   }
 
   connect(peerId) {
@@ -46,6 +59,14 @@ export class ChatWidget {
   addMessage(msg) {
     const div = document.createElement('div');
     div.className = 'chat-message';
+    div.textContent = msg;
+    this.messagesEl.appendChild(div);
+    this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+  }
+
+  addSystemMessage(msg) {
+    const div = document.createElement('div');
+    div.className = 'chat-message system';
     div.textContent = msg;
     this.messagesEl.appendChild(div);
     this.messagesEl.scrollTop = this.messagesEl.scrollHeight;

--- a/src/services/ChatService.js
+++ b/src/services/ChatService.js
@@ -13,6 +13,8 @@ export class ChatService extends EventEmitter {
     if (this.peer) this.peer.destroy?.();
     this.peer = new Peer(username, this.options);
     this.peer.on('connection', conn => this._setupConnection(conn));
+    this.peer.on('open', id => this.emit('open', id));
+    this.peer.on('close', () => this.emit('close'));
     return this.peer;
   }
 
@@ -20,6 +22,8 @@ export class ChatService extends EventEmitter {
     if (!this.peer) {
       this.peer = new Peer(this.options);
       this.peer.on('connection', conn => this._setupConnection(conn));
+      this.peer.on('open', id => this.emit('open', id));
+      this.peer.on('close', () => this.emit('close'));
     }
     const conn = this.peer.connect(peerId);
     this._setupConnection(conn);
@@ -30,6 +34,8 @@ export class ChatService extends EventEmitter {
     this.conn = conn;
     if (!conn) return;
     conn.on('data', data => this.emit('message', data));
+    conn.on('open', () => this.emit('connected'));
+    conn.on('close', () => this.emit('disconnected'));
   }
 
   sendMessage(msg) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -742,4 +742,9 @@ body {
   cursor: pointer;
 }
 
+.chat-message.system {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
 


### PR DESCRIPTION
## Summary
- generate a random id when a ChatWidget is created
- automatically register and notify join/leave events
- emit open/close/connected events in ChatService
- style system chat messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5be7b1748320adb37dabb986548a