### PR TITLE
Handle chat leave on page unload

### DIFF
--- a/src/components/ChatWidget/ChatWidget.js
+++ b/src/components/ChatWidget/ChatWidget.js
@@ -9,8 +9,11 @@ export class ChatWidget {
     this.id = this.generateId();
     this.render();
     this.register(this.id);
-    window.addEventListener('beforeunload', () => {
+    window.addEventListener('beforeunload', async () => {
+      this.service.leave();
       this.service.sendMessage(`${this.id} a quitté le chat`);
+      await new Promise(r => setTimeout(r, 50));
+      this.service.peer?.destroy?.();
     });
   }
 

--- a/src/services/ChatService.js
+++ b/src/services/ChatService.js
@@ -54,4 +54,12 @@ export class ChatService extends EventEmitter {
   onMessage(cb) {
     this.on('message', cb);
   }
+
+  leave() {
+    this.emit('leave');
+  }
+
+  onLeave(cb) {
+    this.on('leave', cb);
+  }
 }

--- a/tests/chatservice.test.js
+++ b/tests/chatservice.test.js
@@ -67,4 +67,11 @@ describe('ChatService', () => {
     expect(c1.send).toHaveBeenCalledTimes(1);
     expect(c2.send).toHaveBeenCalledTimes(2);
   });
+
+  it('emits leave event', () => {
+    const handler = vi.fn();
+    service.onLeave(handler);
+    service.leave();
+    expect(handler).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- allow ChatService to emit `leave` events
- send a leave notification and destroy Peer connection on page unload
- test the new `leave` event

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e6ddcab6c8320b6a791332db5cbeb