### PR TITLE
Load peer server options from config

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -10,5 +10,10 @@
   },
   "lessonsUrl": "/lessons/manifest.json",
   "theme": "dark",
-  "locale": "fr"
+  "locale": "fr",
+  "peerServer": {
+    "host": "0.peerjs.com",
+    "port": 443,
+    "secure": true
+  }
 }

--- a/src/components/ChatWidget/ChatWidget.js
+++ b/src/components/ChatWidget/ChatWidget.js
@@ -1,9 +1,9 @@
 import { ChatService } from '@services/ChatService';
 
 export class ChatWidget {
-  constructor(container) {
+  constructor(container, options) {
     this.container = container;
-    this.service = new ChatService();
+    this.service = new ChatService(options);
     this.messagesEl = null;
     this.inputEl = null;
     this.id = this.generateId();

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -48,6 +48,9 @@ export class CodePlayApp extends EventEmitter {
     try {
       const response = await fetch("config.json");
       this.config = await response.json();
+      if (!this.config.peerServer) {
+        this.config.peerServer = { host: '0.peerjs.com', port: 443, secure: true };
+      }
     } catch (error) {
       // Configuration par défaut
       this.config = {
@@ -57,6 +60,7 @@ export class CodePlayApp extends EventEmitter {
           collaboration: false,
         },
         lessonsUrl: "lessons/manifest.json",
+        peerServer: { host: '0.peerjs.com', port: 443, secure: true },
       };
     }
   }

--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -54,7 +54,10 @@ export class UIManager {
       this.testRunner = new TestRunner(document.getElementById("test-runner"));
 
       if (this.app.config?.features?.collaboration) {
-        this.chatWidget = new ChatWidget(this.elements.chatWidget);
+        this.chatWidget = new ChatWidget(
+          this.elements.chatWidget,
+          this.app.config.peerServer,
+        );
       }
 
       // Gérer les onglets

--- a/src/services/ChatService.js
+++ b/src/services/ChatService.js
@@ -2,11 +2,11 @@ import Peer from 'peerjs';
 import { EventEmitter } from 'eventemitter3';
 
 export class ChatService extends EventEmitter {
-  constructor() {
+  constructor(options = { host: '0.peerjs.com', secure: true, port: 443 }) {
     super();
     this.peer = null;
     this.conns = new Map();
-    this.options = { host: '0.peerjs.com', secure: true, port: 443 };
+    this.options = options;
   }
 
   register(username) {


### PR DESCRIPTION
## Summary
- expose PeerJS server info in `public/config.json`
- surface the peerServer options in `CodePlayApp.loadConfig`
- allow `ChatService` options to be customized
- forward those options from UIManager to ChatWidget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e6f1a5fe88320a739577d3668fd56