### PR TITLE
Load peer server options from config

### DIFF
--- a/src/core/App.js
+++ b/src/core/App.js
@@ -48,9 +48,11 @@ export class CodePlayApp extends EventEmitter {
     try {
       const response = await fetch("config.json");
       this.config = await response.json();
-      if (!this.config.peerServer) {
-        this.config.peerServer = { host: '0.peerjs.com', port: 443, secure: true };
-      }
+      const defaults = { host: '0.peerjs.com', port: 443, secure: true };
+      this.config.peerServer = {
+        ...defaults,
+        ...(this.config.peerServer || {}),
+      };
     } catch (error) {
       // Configuration par défaut
       this.config = {


### PR DESCRIPTION
## Summary
- merge default peer server config with user-provided options

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684e7194946483208a3ccb096c42aacf