### PR TITLE
Implement peer auto-discovery for chat

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -714,6 +714,13 @@ body {
   flex-direction: column;
 }
 
+.chat-status {
+  padding: 4px 8px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-tertiary);
+}
+
 .chat-messages {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- add `listPeers` to `ChatService` and auto-connect to discovered peers
- expose peer connection events with peer IDs
- show connected users in `ChatWidget`
- style chat status bar
- test peer discovery logic

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684e736b2bf88320b11a218c6aff19ec