### PR TITLE
Implement peer auto-connect and status counts

### DIFF
--- a/src/components/ChatWidget/ChatWidget.js
+++ b/src/components/ChatWidget/ChatWidget.js
@@ -95,8 +95,10 @@ export class ChatWidget {
     const peers = Array.from(this.connectedPeers);
     if (peers.length === 0) {
       this.statusEl.textContent = 'Aucun autre utilisateur en ligne';
-    } else {
+    } else if (peers.length <= 3) {
       this.statusEl.textContent = `Connectés: ${peers.join(', ')}`;
+    } else {
+      this.statusEl.textContent = `${peers.length} utilisateurs en ligne`;
     }
   }
 


### PR DESCRIPTION
## Summary
- auto-connect to discovered peers in `ChatService`
- show connected peers or counts in `ChatWidget`

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684e79c289c88320b2f956f35e2cd943