### PR TITLE
Handle 404 in ChatService listPeers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ The app ships with a small chat widget powered by [PeerJS](https://peerjs.com/).
 To enable it, set `"collaboration": true` in `public/config.json` (or `"chat"` if
 present). After rebuilding, a chat panel will appear at the bottom of the UI
 allowing connected peers to exchange short messages.
+
+The chat widget connects to the public PeerServer at `0.peerjs.com` by default.
+You can override the `host`, `port` and `path` via the `peerServer` section of
+`public/config.json`, or point these settings at your own PeerServer instance if
+you prefer to run one privately.

--- a/src/services/ChatService.js
+++ b/src/services/ChatService.js
@@ -17,6 +17,9 @@ export class ChatService extends EventEmitter {
     const basePath = this.options.path || '/';
     const url = `${protocol}://${this.options.host}${port}${basePath.replace(/\/$/, '')}/peers`;
     const res = await fetch(url);
+    if (res.status === 404) {
+      return [];
+    }
     if (!res.ok) {
       throw new Error(`Failed to fetch peers: ${res.status}`);
     }

--- a/tests/chatservice.test.js
+++ b/tests/chatservice.test.js
@@ -134,6 +134,12 @@ describe('ChatService', () => {
     expect(peers).toEqual(['a', 'b']);
   });
 
+  it('listPeers returns empty array on 404', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    service.options = { host: 'host', secure: false, port: 80 };
+    await expect(service.listPeers()).resolves.toEqual([]);
+  });
+
   it('auto connects to peers on open', async () => {
     const connectSpy = vi.spyOn(service, 'connect');
     service.register('me');


### PR DESCRIPTION
## Summary
- avoid throwing on 404 responses in `listPeers`
- test ChatService 404 behavior
- document PeerServer configuration in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eceee92f08320a48d39477e2697ef