### PR TITLE
Switch chat to simple-peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,20 @@ This builds the project and publishes the `dist` folder using the `gh-pages` pac
 
 ## Collaboration Chat
 
-The app ships with a small chat widget powered by [PeerJS](https://peerjs.com/).
-To enable it, set `"collaboration": true` in `public/config.json` (or `"chat"` if
-present). After rebuilding, a chat panel will appear at the bottom of the UI
-allowing connected peers to exchange short messages.
+The app ships with a small chat widget powered by [simple-peer](https://github.com/feross/simple-peer).
+Enable it by setting `"collaboration": true` in `public/config.json` (or `"chat"` if present).
+Once enabled, a chat panel appears at the bottom of the UI allowing connected peers to exchange short messages.
 
-The chat widget connects to the public PeerServer at `0.peerjs.com` by default.
-You can override the `host`, `port` and `path` via the `peerServer` section of
-`public/config.json`, or point these settings at your own PeerServer instance if
-you prefer to run one privately. The `peerServer` section also accepts an
-optional `rtcConfig` object which is passed directly to
-`RTCPeerConnection` when establishing WebRTC connections (e.g. to specify custom
-`iceServers`).
+Peers discover each other and exchange WebRTC signals through a small Cloudflare Worker.
+Configure its endpoint using the `registerServer` section of `public/config.json`:
+
+```json
+{
+  "registerServer": {
+    "registerUrl": "https://your-worker.example.com",
+    "rtcConfig": { "iceServers": [{ "urls": "stun:stun.l.google.com:19302" }] }
+  }
+}
+```
+
+`rtcConfig` is passed directly to `simple-peer` when creating the `RTCPeerConnection` and can be used to specify custom ICE servers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "eventemitter3": "^5.0.1",
         "localforage": "^1.10.0",
         "monaco-editor": "^0.44.0",
-        "peerjs": "^1.5.2",
+        "simple-peer": "^9.11.1",
         "vite-plugin-monaco-editor": "^1.1.0"
       },
       "devDependencies": {
@@ -746,15 +746,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@msgpack/msgpack": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
-      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1495,6 +1486,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -1523,6 +1534,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -1700,7 +1735,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1796,6 +1830,12 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2281,6 +2321,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
+      "license": "MIT"
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -2481,6 +2527,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2540,7 +2606,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-extglob": {
@@ -2912,7 +2977,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3146,44 +3210,6 @@
         "node": "*"
       }
     },
-    "node_modules/peerjs": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.5.tgz",
-      "integrity": "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@msgpack/msgpack": "^2.8.0",
-        "eventemitter3": "^4.0.7",
-        "peerjs-js-binarypack": "^2.1.0",
-        "webrtc-adapter": "^9.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/peer"
-      }
-    },
-    "node_modules/peerjs-js-binarypack": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
-      "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/peer"
-      }
-    },
-    "node_modules/peerjs/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3389,7 +3415,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3406,12 +3431,35 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3522,6 +3570,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3541,12 +3609,6 @@
       "engines": {
         "node": ">=v12.22.7"
       }
-    },
-    "node_modules/sdp": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
-      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -3599,6 +3661,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-peer": {
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
+      "integrity": "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "debug": "^4.3.2",
+        "err-code": "^3.0.1",
+        "get-browser-rtc": "^1.1.0",
+        "queue-microtask": "^1.2.3",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "node_modules/slash": {
@@ -3659,6 +3750,15 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -3977,6 +4077,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "5.4.19",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
@@ -4156,19 +4262,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/webrtc-adapter": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
-      "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "sdp": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.10.0"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eventemitter3": "^5.0.1",
     "localforage": "^1.10.0",
     "monaco-editor": "^0.44.0",
-    "peerjs": "^1.5.2",
+    "simple-peer": "^9.11.1",
     "vite-plugin-monaco-editor": "^1.1.0"
   },
   "devDependencies": {

--- a/public/config.json
+++ b/public/config.json
@@ -11,10 +11,8 @@
   "lessonsUrl": "/lessons/manifest.json",
   "theme": "dark",
   "locale": "fr",
-  "peerServer": {
-    "host": "0.peerjs.com",
-    "port": 443,
-    "secure": true,
+  "registerServer": {
+    "registerUrl": "",
     "rtcConfig": {
       "iceServers": [
         { "urls": "stun:stun.l.google.com:19302" }

--- a/src/components/ChatWidget/ChatWidget.js
+++ b/src/components/ChatWidget/ChatWidget.js
@@ -18,7 +18,6 @@ export class ChatWidget {
     this.service.leave();
     this.service.sendMessage(`${this.id} a quitté le chat`);
     await new Promise(r => setTimeout(r, 50));
-    this.service.peer?.destroy?.();
   }
 
   render() {

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -48,11 +48,11 @@ export class CodePlayApp extends EventEmitter {
     try {
       const response = await fetch("config.json");
       this.config = await response.json();
-      const defaults = { host: '0.peerjs.com', port: 443, secure: true, rtcConfig: null };
-      const { peerServer = {} } = this.config;
-      this.config.peerServer = {
+      const defaults = { registerUrl: '', rtcConfig: null };
+      const { registerServer = {} } = this.config;
+      this.config.registerServer = {
         ...defaults,
-        ...peerServer,
+        ...registerServer,
       };
     } catch (error) {
       // Configuration par défaut
@@ -63,7 +63,7 @@ export class CodePlayApp extends EventEmitter {
           collaboration: false,
         },
         lessonsUrl: "lessons/manifest.json",
-        peerServer: { host: '0.peerjs.com', port: 443, secure: true, rtcConfig: null },
+        registerServer: { registerUrl: '', rtcConfig: null },
       };
     }
   }

--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -56,7 +56,7 @@ export class UIManager {
       if (this.app.config?.features?.collaboration) {
         this.chatWidget = new ChatWidget(
           this.elements.chatWidget,
-          this.app.config.peerServer,
+          this.app.config.registerServer,
         );
       }
 

--- a/tests/chatservice.test.js
+++ b/tests/chatservice.test.js
@@ -2,63 +2,33 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { ChatService } from '@/services/ChatService';
 
-class MockConn extends EventEmitter {
-  constructor(peer) {
+class MockPeer extends EventEmitter {
+  constructor(opts) {
     super();
-    this.open = true;
-    this.peer = peer;
+    this.opts = opts;
+    this.connected = false;
   }
   send = vi.fn();
-}
-
-class MockPeer extends EventEmitter {
-  constructor(id) {
-    super();
-    this.id = id;
-  }
-  connect(peerId) {
-    const conn = new MockConn(peerId);
-    this.conn = conn;
-    return conn;
-  }
-  destroy() {}
-}
-
-vi.mock('peerjs', () => ({ default: vi.fn(id => new MockPeer(id)) }));
-
-class MockDataChannel {
-  constructor() {
-    this.readyState = 'open';
-    this.send = vi.fn();
-    this.onmessage = null;
-    this.onclose = null;
-  }
-  close() {
-    this.readyState = 'closed';
-    this.onclose && this.onclose();
+  signal() {}
+  destroy() {
+    this.emit('close');
   }
 }
 
-class MockRTC extends EventEmitter {
-  constructor() {
-    super();
-    this.onicecandidate = null;
-    this.ondatachannel = null;
-  }
-  createDataChannel() {
-    this.channel = new MockDataChannel();
-    return this.channel;
-  }
-  async createOffer() { return { type: 'offer', sdp: 'offer' }; }
-  async createAnswer() { return { type: 'answer', sdp: 'answer' }; }
-  async setLocalDescription(desc) { this.local = desc; }
-  async setRemoteDescription(desc) { this.remote = desc; }
-  async addIceCandidate() {}
-  close() {}
-}
+var MockPeerCtor;
+vi.mock('simple-peer', () => {
+  MockPeerCtor = vi.fn(opts => new MockPeer(opts));
+  return { default: MockPeerCtor };
+});
 
 beforeEach(() => {
-  global.RTCPeerConnection = vi.fn(() => new MockRTC());
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('ChatService', () => {
@@ -66,54 +36,44 @@ describe('ChatService', () => {
 
   beforeEach(() => {
     service = new ChatService();
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
-    );
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it('register stores username', async () => {
+    await service.register('alice');
+    expect(service.id).toBe('alice');
   });
 
-  it('register creates Peer with username', () => {
-    service.register('alice');
-    expect(service.peer.id).toBe('alice');
-  });
-
-  it('dispatches received messages', async () => {
+  it('dispatches received messages', () => {
     service.register('bob');
     const conn = service.connect('remote');
     const handler = vi.fn();
     service.onMessage(handler);
-    conn.emit('open');
-    await Promise.resolve();
-    const channel = service.channels.get('remote');
-    channel.onmessage({ data: 'hi' });
+    conn.emit('connect');
+    service.peers.get('remote').emit('data', 'hi');
     expect(handler).toHaveBeenCalledWith('hi');
     service.sendMessage('hello');
-    expect(channel.send).toHaveBeenCalledWith('hello');
+    expect(conn.send).toHaveBeenCalledWith('hello');
   });
 
-  it('broadcasts to multiple peers and removes closed connections', async () => {
+  it('broadcasts to multiple peers and removes closed connections', () => {
     service.register('carol');
     const c1 = service.connect('peer1');
     const c2 = service.connect('peer2');
     const handler = vi.fn();
     service.onMessage(handler);
-    c1.emit('open');
-    c2.emit('open');
-    await Promise.resolve();
-    service.channels.get('peer1').onmessage({ data: 'msg1' });
-    service.channels.get('peer2').onmessage({ data: 'msg2' });
+    c1.emit('connect');
+    c2.emit('connect');
+    service.peers.get('peer1').emit('data', 'msg1');
+    service.peers.get('peer2').emit('data', 'msg2');
     expect(handler).toHaveBeenCalledWith('msg1');
     expect(handler).toHaveBeenCalledWith('msg2');
     service.sendMessage('hi all');
-    expect(service.channels.get('peer1').send).toHaveBeenCalledWith('hi all');
-    expect(service.channels.get('peer2').send).toHaveBeenCalledWith('hi all');
+    expect(c1.send).toHaveBeenCalledWith('hi all');
+    expect(c2.send).toHaveBeenCalledWith('hi all');
     c1.emit('close');
     service.sendMessage('bye');
-    expect(service.channels.get('peer1')).toBeUndefined();
-    expect(service.channels.get('peer2').send).toHaveBeenCalledTimes(2);
+    expect(service.peers.has('peer1')).toBe(false);
+    expect(c2.send).toHaveBeenCalledTimes(2);
   });
 
   it('emits leave event', () => {
@@ -128,7 +88,7 @@ describe('ChatService', () => {
       ok: true,
       json: () => Promise.resolve(['a', 'b'])
     });
-    service.options = { host: 'host', secure: false, port: 80 };
+    service.options = { registerUrl: 'http://host:80' };
     const peers = await service.listPeers();
     expect(fetch).toHaveBeenCalledWith('http://host:80/peers');
     expect(peers).toEqual(['a', 'b']);
@@ -136,16 +96,14 @@ describe('ChatService', () => {
 
   it('listPeers returns empty array on 404', async () => {
     global.fetch.mockResolvedValueOnce({ ok: false, status: 404 });
-    service.options = { host: 'host', secure: false, port: 80 };
+    service.options = { registerUrl: 'http://host:80' };
     await expect(service.listPeers()).resolves.toEqual([]);
   });
 
-  it('auto connects to peers on open', async () => {
+  it('auto connects to peers on register', async () => {
     const connectSpy = vi.spyOn(service, 'connect');
-    service.register('me');
     vi.spyOn(service, 'listPeers').mockResolvedValue(['me', 'other1']);
-    service.peer.emit('open', 'me');
-    await new Promise(resolve => setImmediate(resolve));
+    await service.register('me');
     expect(connectSpy).toHaveBeenCalledWith('other1');
   });
 
@@ -154,14 +112,16 @@ describe('ChatService', () => {
     const conn = service.connect('y');
     const handler = vi.fn();
     service.on('connected', handler);
-    conn.emit('open');
+    conn.emit('connect');
     expect(handler).toHaveBeenCalledWith('y');
   });
 
-  it('creates RTCPeerConnection with config', () => {
+  it('passes rtcConfig to simple-peer', () => {
+    service = new ChatService({ registerUrl: '', rtcConfig: { iceServers: [] } });
     service.register('p');
-    const conn = service.connect('z');
-    conn.emit('open');
-    expect(global.RTCPeerConnection).toHaveBeenCalledWith(expect.any(Object));
+    service.connect('z');
+    expect(MockPeerCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ config: { iceServers: [] } })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- replace PeerJS with simple-peer for chat connections
- update Cloudflare register handling in ChatService
- rename peerServer -> registerServer in config and app
- adjust ChatWidget unload behavior
- update tests to mock simple-peer
- document new worker configuration

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f1916bf3483209b9381ed4a74b06c