### PR TITLE
Add register worker deploy workflow

### DIFF
--- a/.github/workflows/register-deploy.yml
+++ b/.github/workflows/register-deploy.yml
@@ -1,0 +1,35 @@
+# .github/workflows/register-deploy.yml
+name: Deploy Register Worker
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: register/package-lock.json
+
+      - name: Install dependencies
+        working-directory: register
+        run: npm ci
+
+      - name: Publish Worker
+        working-directory: register
+        run: npx wrangler publish --name "$CLOUDFLARE_WORKER_NAME"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_WORKER_NAME: ${{ secrets.CLOUDFLARE_WORKER_NAME }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy Cloudflare worker

## Testing
- `npx vitest run` *(fails: Failed to load url cloudflare:test)*

------
https://chatgpt.com/codex/tasks/task_e_684fd37e800c83209c41aa1f0eb5d2b0