### PR TITLE
Add CORS handling to register workers

### DIFF
--- a/register-worker/src/index.js
+++ b/register-worker/src/index.js
@@ -1,22 +1,32 @@
 const peers = new Set();
 const signals = new Map();
 
+const cors = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS'
+};
+
 export default {
   async fetch(request) {
     const url = new URL(request.url);
     const { pathname } = url;
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: cors });
+    }
 
     if (pathname === '/register' && request.method === 'POST') {
       const { id } = await request.json();
       if (!id) return new Response('Missing id', { status: 400 });
       peers.add(id);
       if (!signals.has(id)) signals.set(id, []);
-      return new Response('OK');
+      return new Response('OK', { headers: { ...cors } });
     }
 
     if (pathname === '/peers' && request.method === 'GET') {
       return new Response(JSON.stringify([...peers]), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json', ...cors }
       });
     }
 
@@ -26,7 +36,7 @@ export default {
         return new Response('Invalid', { status: 400 });
       if (!signals.has(to)) signals.set(to, []);
       signals.get(to).push({ from, signal });
-      return new Response('OK');
+      return new Response('OK', { headers: { ...cors } });
     }
 
     if (pathname === '/signal' && request.method === 'GET') {
@@ -35,10 +45,10 @@ export default {
       const list = signals.get(id) || [];
       signals.set(id, []);
       return new Response(JSON.stringify(list), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json', ...cors }
       });
     }
 
-    return new Response('Not found', { status: 404 });
+    return new Response('Not found', { status: 404, headers: { ...cors } });
   }
 };

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -1,22 +1,32 @@
 const peers = new Set();
 const signals = new Map();
 
+const cors = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS'
+};
+
 export default {
   async fetch(request) {
     const url = new URL(request.url);
     const { pathname } = url;
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: cors });
+    }
 
     if (pathname === '/register' && request.method === 'POST') {
       const { id } = await request.json();
       if (!id) return new Response('Missing id', { status: 400 });
       peers.add(id);
       if (!signals.has(id)) signals.set(id, []);
-      return new Response('OK');
+      return new Response('OK', { headers: { ...cors } });
     }
 
     if (pathname === '/peers' && request.method === 'GET') {
       return new Response(JSON.stringify([...peers]), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json', ...cors }
       });
     }
 
@@ -26,7 +36,7 @@ export default {
         return new Response('Invalid', { status: 400 });
       if (!signals.has(to)) signals.set(to, []);
       signals.get(to).push({ from, signal });
-      return new Response('OK');
+      return new Response('OK', { headers: { ...cors } });
     }
 
     if (pathname === '/signal' && request.method === 'GET') {
@@ -35,10 +45,10 @@ export default {
       const list = signals.get(id) || [];
       signals.set(id, []);
       return new Response(JSON.stringify(list), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json', ...cors }
       });
     }
 
-    return new Response('Not found', { status: 404 });
+    return new Response('Not found', { status: 404, headers: { ...cors } });
   }
 };

--- a/register/test/index.spec.js
+++ b/register/test/index.spec.js
@@ -2,19 +2,19 @@ import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloud
 import { describe, it, expect } from 'vitest';
 import worker from '../src';
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new Request('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+describe('register worker CORS', () => {
+  it('responds to OPTIONS with CORS headers', async () => {
+    const request = new Request('http://example.com/register', { method: 'OPTIONS' });
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('http://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+  it('returns 404 with CORS headers for unknown route', async () => {
+    const response = await SELF.fetch('http://example.com/unknown');
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+import base from './vite.config.js';
+
+export default defineConfig({
+  ...base,
+  test: {
+    exclude: [...configDefaults.exclude, 'register/**']
+  }
+});


### PR DESCRIPTION
## Summary
- return CORS headers from worker endpoints
- handle OPTIONS requests in both workers
- test CORS headers for register worker
- ignore worker tests from root `vitest`

## Testing
- `npm test` within `register`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685091c40d248320835b7cc56a452f7a