### PR TITLE
Use durable object for peer register

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,14 @@ Configure its endpoint using the `registerServer` section of `public/config.json
 ```
 
 `rtcConfig` is passed directly to `simple-peer` when creating the `RTCPeerConnection` and can be used to specify custom ICE servers.
+
+### Deploying the Worker
+
+The signaling API uses a Cloudflare Durable Object to persist the list of peers and pending signals. Deploy it from the `register` directory:
+
+```bash
+cd register
+npm run deploy
+```
+
+The first deployment creates the Durable Object using the configuration in `wrangler.jsonc`.

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -1,14 +1,33 @@
-const peers = new Set();
-const signals = new Map();
-
 const cors = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS'
 };
 
-export default {
+export class PeerManager {
+  constructor(state) {
+    this.state = state;
+    this.peers = null;
+    this.signals = null;
+  }
+
+  async _load() {
+    if (!this.peers) {
+      this.peers = new Set((await this.state.storage.get('peers')) || []);
+    }
+    if (!this.signals) {
+      const entries = (await this.state.storage.get('signals')) || [];
+      this.signals = new Map(entries);
+    }
+  }
+
+  async _save() {
+    await this.state.storage.put('peers', [...this.peers]);
+    await this.state.storage.put('signals', [...this.signals.entries()]);
+  }
+
   async fetch(request) {
+    await this._load();
     const url = new URL(request.url);
     const { pathname } = url;
 
@@ -19,13 +38,14 @@ export default {
     if (pathname === '/register' && request.method === 'POST') {
       const { id } = await request.json();
       if (!id) return new Response('Missing id', { status: 400 });
-      peers.add(id);
-      if (!signals.has(id)) signals.set(id, []);
+      this.peers.add(id);
+      if (!this.signals.has(id)) this.signals.set(id, []);
+      await this._save();
       return new Response('OK', { headers: { ...cors } });
     }
 
     if (pathname === '/peers' && request.method === 'GET') {
-      return new Response(JSON.stringify([...peers]), {
+      return new Response(JSON.stringify([...this.peers]), {
         headers: { 'Content-Type': 'application/json', ...cors }
       });
     }
@@ -34,21 +54,31 @@ export default {
       const { from, to, signal } = await request.json();
       if (!from || !to || signal === undefined)
         return new Response('Invalid', { status: 400 });
-      if (!signals.has(to)) signals.set(to, []);
-      signals.get(to).push({ from, signal });
+      if (!this.signals.has(to)) this.signals.set(to, []);
+      this.signals.get(to).push({ from, signal });
+      await this._save();
       return new Response('OK', { headers: { ...cors } });
     }
 
     if (pathname === '/signal' && request.method === 'GET') {
       const id = url.searchParams.get('id');
       if (!id) return new Response('Missing id', { status: 400 });
-      const list = signals.get(id) || [];
-      signals.set(id, []);
+      const list = this.signals.get(id) || [];
+      this.signals.set(id, []);
+      await this._save();
       return new Response(JSON.stringify(list), {
         headers: { 'Content-Type': 'application/json', ...cors }
       });
     }
 
     return new Response('Not found', { status: 404, headers: { ...cors } });
+  }
+};
+
+export default {
+  async fetch(request, env) {
+    const id = env.PEER_MANAGER.idFromName('global');
+    const stub = env.PEER_MANAGER.get(id);
+    return stub.fetch(request);
   }
 };

--- a/register/test/index.spec.js
+++ b/register/test/index.spec.js
@@ -1,4 +1,4 @@
-import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 import worker from '../src';
 
@@ -13,7 +13,10 @@ describe('register worker CORS', () => {
   });
 
   it('returns 404 with CORS headers for unknown route', async () => {
-    const response = await SELF.fetch('http://example.com/unknown');
+    const request = new Request('http://example.com/unknown');
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
     expect(response.status).toBe(404);
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
   });

--- a/register/wrangler.jsonc
+++ b/register/wrangler.jsonc
@@ -5,12 +5,23 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "register",
-	"main": "src/index.js",
-	"workers_dev": true,
-	"compatibility_date": "2025-06-14",
-	"observability": {
-		"enabled": true
-	}
+        "main": "src/index.js",
+        "workers_dev": true,
+        "compatibility_date": "2025-06-14",
+        "observability": {
+                "enabled": true
+        },
+        "durable_objects": {
+                "bindings": [
+                        { "name": "PEER_MANAGER", "class_name": "PeerManager" }
+                ]
+        },
+        "migrations": [
+                {
+                        "tag": "v1",
+                        "new_classes": ["PeerManager"]
+                }
+        ]
 	/**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
## Summary
- persist peer info in a `PeerManager` durable object
- bind worker to the durable object in `wrangler.jsonc`
- mention durable object deployment in README
- adjust test to call worker directly without `SELF.fetch`

## Testing
- `npm test` *(fails: Isolated storage failed)*

------
https://chatgpt.com/codex/tasks/task_e_685095d03e108320883564204715b3a6