### PR TITLE
Add global define for vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ Start a local development server with Vite:
 npm run dev
 ```
 
-The app will be available at the URL printed in the console.
+The app will be available at the URL printed in the console. If you see a
+"global is not defined" error, ensure `vite.config.js` contains:
+
+```js
+define: { global: 'globalThis' }
+```
+which exposes the Node-style `global` variable during development.
 
 ## Deploy
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
   ],
   // Use a relative base path in production that matches the repository name
   base: process.env.NODE_ENV === 'production' ? '/stage2nd/' : '/',
+  define: { global: 'globalThis' },
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- fix globalThis issue by defining `global` in Vite config
- document Vite global fix in README

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6851cabbebd48320bdfbe49e944382a2