### PR TITLE
Fix LessonManager test setup

### DIFF
--- a/src/core/LessonManager.js
+++ b/src/core/LessonManager.js
@@ -299,7 +299,9 @@ ${exercise.difficulty}
       }
 
       // Combiner le code de l'utilisateur et les tests
-      const combined = `${code}\n${testCode}`;
+      const combined =
+        `const code = ${JSON.stringify(code)};\n` +
+        `${code}\n${testCode}`;
 
       // Créer une fonction de test exécutant d'abord le code puis les tests
       const testFunction = new Function('output', 'results', combined);


### PR DESCRIPTION
## Summary
- ensure LessonManager passes the user's code as a string when running tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6851ce9d730c8320bded7f381bc4ed73