### PR TITLE
Fix join message timing in chat

### DIFF
--- a/src/components/ChatWidget/ChatWidget.js
+++ b/src/components/ChatWidget/ChatWidget.js
@@ -15,9 +15,9 @@ export class ChatWidget {
   }
 
   async handleUnload() {
-    this.service.leave();
     this.service.sendMessage(`${this.id} a quitté le chat`);
     await new Promise(r => setTimeout(r, 50));
+    this.service.leave();
   }
 
   render() {
@@ -47,12 +47,13 @@ export class ChatWidget {
     this.service.register(username);
     this.service.onMessage(msg => this.addMessage(msg));
     this.service.on('open', () => {
-      this.service.sendMessage(`${username} a rejoint le chat`);
       this.addSystemMessage(`Connecté en tant que ${username}`);
       this.updateStatus();
     });
     this.service.on('connected', id => {
       this.connectedPeers.add(id);
+      const peer = this.service.peers.get(id);
+      try { peer?.send(`${username} a rejoint le chat`); } catch {}
       this.updateStatus();
     });
     this.service.on('disconnected', id => {


### PR DESCRIPTION
## Summary
- ensure disconnect message is sent before closing connections
- announce join to each peer after connection

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6851c9ad8dcc8320ade05b6d4a6f59f5