### PR TITLE
Add workspace tab navigation

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -29,6 +29,8 @@ export class UIManager {
       progressFill: document.getElementById("progress-fill"),
       testRunner: document.getElementById("test-runner"),
       chatWidget: document.getElementById("chat-widget"),
+      workspaceTabs: document.querySelectorAll(".workspace-tab"),
+      workspacePanels: document.querySelectorAll(".workspace-panel"),
     };
 
     // Vérifier que les éléments critiques existent
@@ -62,6 +64,7 @@ export class UIManager {
 
       // Gérer les onglets
       this.setupOutputTabs();
+      this.setupWorkspaceTabs();
 
       // Configurer les événements
       this.setupEventListeners();
@@ -107,26 +110,33 @@ export class UIManager {
         </aside>
         
         <section class="workspace">
-          <div class="lesson-info" id="lesson-info">
-            <div class="welcome-screen">
-              <h2>Bienvenue dans CodePlay ! 👋</h2>
-              <p>Sélectionne une leçon pour commencer</p>
-            </div>
+          <div class="workspace-tabs" role="tablist">
+            <button class="workspace-tab active" data-panel="lesson" role="tab" aria-controls="lesson-panel">Énoncé</button>
+            <button class="workspace-tab" data-panel="editor" role="tab" aria-controls="editor-panel">Workspace</button>
           </div>
-          
-          <div class="editor-container">
-            <div class="editor-toolbar">
-              <button class="btn-primary" id="btn-run">
-                ▶️ Exécuter
-              </button>
-              <button class="btn-secondary" id="btn-reset">
-                🔄 Réinitialiser
-              </button>
+          <div class="workspace-panels">
+            <div class="workspace-panel active" id="lesson-panel">
+              <div class="lesson-info" id="lesson-info">
+                <div class="welcome-screen">
+                  <h2>Bienvenue dans CodePlay ! 👋</h2>
+                  <p>Sélectionne une leçon pour commencer</p>
+                </div>
+              </div>
             </div>
-            <div id="editor" class="editor"></div>
-          </div>
-          
-          <div class="output-container" id="output-container">
+            <div class="workspace-panel" id="editor-panel">
+              <div class="editor-container">
+                <div class="editor-toolbar">
+                  <button class="btn-primary" id="btn-run">
+                    ▶️ Exécuter
+                  </button>
+                  <button class="btn-secondary" id="btn-reset">
+                    🔄 Réinitialiser
+                  </button>
+                </div>
+                <div id="editor" class="editor"></div>
+              </div>
+
+              <div class="output-container" id="output-container">
   <div class="output-tabs">
     <button class="output-tab active" data-panel="console">Console</button>
     <button class="output-tab" data-panel="network">Réseau</button>
@@ -144,7 +154,9 @@ export class UIManager {
     </div>
   </div>
 </div>
-          <div id="chat-widget"></div>
+              <div id="chat-widget"></div>
+            </div>
+          </div>
         </section>
       </main>
     `;
@@ -323,6 +335,26 @@ export class UIManager {
         panels.forEach((panel) => {
           panel.classList.remove("active");
           if (panel.id === `${targetPanel}-panel`) {
+            panel.classList.add("active");
+          }
+        });
+      });
+    });
+  }
+
+  setupWorkspaceTabs() {
+    const { workspaceTabs: tabs, workspacePanels: panels } = this.elements;
+
+    tabs.forEach((tab) => {
+      tab.addEventListener("click", () => {
+        const target = tab.dataset.panel;
+
+        tabs.forEach((t) => t.classList.remove("active"));
+        tab.classList.add("active");
+
+        panels.forEach((panel) => {
+          panel.classList.remove("active");
+          if (panel.id === `${target}-panel`) {
             panel.classList.add("active");
           }
         });

--- a/src/index.html
+++ b/src/index.html
@@ -36,26 +36,53 @@
       </aside>
       
       <section class="workspace">
-        <div class="lesson-info" id="lesson-info">
-          <div class="welcome-screen">
-            <h2>Bienvenue dans CodePlay ! 👋</h2>
-            <p>Sélectionne une leçon pour commencer</p>
+        <div class="workspace-tabs" role="tablist">
+          <button class="workspace-tab active" data-panel="lesson" role="tab" aria-controls="lesson-panel">Énoncé</button>
+          <button class="workspace-tab" data-panel="editor" role="tab" aria-controls="editor-panel">Workspace</button>
+        </div>
+        <div class="workspace-panels">
+          <div class="workspace-panel active" id="lesson-panel">
+            <div class="lesson-info" id="lesson-info">
+              <div class="welcome-screen">
+                <h2>Bienvenue dans CodePlay ! 👋</h2>
+                <p>Sélectionne une leçon pour commencer</p>
+              </div>
+            </div>
+          </div>
+          <div class="workspace-panel" id="editor-panel">
+            <div class="editor-container">
+              <div class="editor-toolbar">
+                <button class="btn-primary" id="btn-run">
+                  ▶️ Exécuter
+                </button>
+                <button class="btn-secondary" id="btn-reset">
+                  🔄 Réinitialiser
+                </button>
+              </div>
+              <div id="editor" class="editor"></div>
+            </div>
+
+            <div class="output-container" id="output-container">
+  <div class="output-tabs">
+    <button class="output-tab active" data-panel="console">Console</button>
+    <button class="output-tab" data-panel="network">Réseau</button>
+    <button class="output-tab" data-panel="tests">Tests</button>
+  </div>
+  <div class="output-panels">
+    <div class="output-panel active" id="console-panel">
+      <div id="console"></div>
+    </div>
+    <div class="output-panel" id="network-panel">
+      <div id="network-monitor"></div>
+    </div>
+  <div class="output-panel" id="tests-panel">
+      <div id="test-runner"></div>
+    </div>
+  </div>
+</div>
+            <div id="chat-widget"></div>
           </div>
         </div>
-        
-        <div class="editor-container">
-          <div class="editor-toolbar">
-            <button class="btn-primary" id="btn-run">
-              ▶️ Exécuter
-            </button>
-            <button class="btn-secondary" id="btn-reset">
-              🔄 Réinitialiser
-            </button>
-          </div>
-          <div id="editor" class="editor"></div>
-        </div>
-        
-        <div class="console-container" id="console"></div>
       </section>
     </main>
   </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -92,7 +92,7 @@ body {
 .workspace {
   flex: 1;
   display: grid;
-  grid-template-rows: auto 1fr 250px;
+  grid-template-rows: auto 1fr;
   gap: 1px;
   background-color: var(--border-color);
   overflow: hidden;
@@ -280,7 +280,7 @@ body {
   }
 
   .workspace {
-    grid-template-rows: auto 1fr 200px;
+    grid-template-rows: auto 1fr;
   }
 }
 
@@ -574,6 +574,47 @@ body {
 }
 
 .output-panel.active {
+  display: block;
+}
+
+/* Tabs pour la zone de travail */
+.workspace-tabs {
+  display: flex;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.workspace-tab {
+  padding: 10px 20px;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s;
+}
+
+.workspace-tab:hover {
+  color: var(--text-primary);
+}
+
+.workspace-tab.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.workspace-panels {
+  position: relative;
+  height: calc(100% - 42px);
+}
+
+.workspace-panel {
+  position: absolute;
+  inset: 0;
+  display: none;
+}
+
+.workspace-panel.active {
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- insert new workspace tabs in index.html
- create the same structure in `UIManager.createUI`
- keep references to the workspace tabs and panels
- toggle workspace views with `setupWorkspaceTabs`
- style the new workspace panels and adjust workspace grid

## Testing
- `npm test`
- `npm run dev` *(fails to fully run in background, but build output shown)*

------
https://chatgpt.com/codex/tasks/task_e_6855ac73179483208d9aa2900141ca40