### PR TITLE
Move run/reset buttons to floating toolbar

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -125,7 +125,8 @@ export class UIManager {
             </div>
             <div class="workspace-panel" id="editor-panel">
               <div class="editor-container">
-                <div class="editor-toolbar">
+                <div id="editor" class="editor"></div>
+                <div class="floating-actions">
                   <button class="btn-primary" id="btn-run">
                     ▶️ Exécuter
                   </button>
@@ -133,7 +134,6 @@ export class UIManager {
                     🔄 Réinitialiser
                   </button>
                 </div>
-                <div id="editor" class="editor"></div>
               </div>
 
               <div class="output-container" id="output-container">

--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,8 @@
           </div>
           <div class="workspace-panel" id="editor-panel">
             <div class="editor-container">
-              <div class="editor-toolbar">
+              <div id="editor" class="editor"></div>
+              <div class="floating-actions">
                 <button class="btn-primary" id="btn-run">
                   ▶️ Exécuter
                 </button>
@@ -59,7 +60,6 @@
                   🔄 Réinitialiser
                 </button>
               </div>
-              <div id="editor" class="editor"></div>
             </div>
 
             <div class="output-container" id="output-container">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2,6 +2,8 @@
 :root {
   --color-primary: #667eea;
   --color-primary-dark: #5a67d8;
+  --color-secondary: #4a5568;
+  --color-secondary-dark: #2d3748;
   --color-success: #48bb78;
   --color-danger: #f56565;
   --color-warning: #ed8936;
@@ -139,12 +141,13 @@ body {
   flex-direction: column;
 }
 
-.editor-toolbar {
-  background-color: var(--bg-secondary);
-  padding: 10px;
+.floating-actions {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
   display: flex;
   gap: 10px;
-  border-bottom: 1px solid var(--border-color);
+  z-index: 50;
 }
 
 .editor {
@@ -221,12 +224,12 @@ body {
 }
 
 .btn-secondary {
-  background-color: var(--bg-tertiary);
-  color: var(--text-primary);
+  background-color: var(--color-secondary);
+  color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #5a6578;
+  background-color: var(--color-secondary-dark);
 }
 
 .btn-icon {


### PR DESCRIPTION
## Summary
- move run/reset actions into a floating toolbar in the editor panel
- style floating action area and update secondary button colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856561b9b708320981d4220ea2963cd