### PR TITLE
Add floating Chat widget with toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This builds the project and publishes the `dist` folder using the `gh-pages` pac
 
 The app ships with a small chat widget powered by [simple-peer](https://github.com/feross/simple-peer).
 Enable it by setting `"collaboration": true` in `public/config.json` (or `"chat"` if present).
-Once enabled, a chat panel appears at the bottom of the UI allowing connected peers to exchange short messages.
+Once enabled, a chat panel appears as a floating widget that can be toggled using the **Chat** button next to *Exécuter* and *Réinitialiser*.
 
 Peers discover each other and exchange WebRTC signals through a small Cloudflare Worker.
 Configure its endpoint using the `registerServer` section of `public/config.json`:

--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -26,12 +26,17 @@ export class UIManager {
       courseSelector: document.getElementById("course-selector"),
       runButton: document.getElementById("btn-run"),
       resetButton: document.getElementById("btn-reset"),
+      chatToggleButton: document.getElementById("btn-chat-toggle"),
       progressFill: document.getElementById("progress-fill"),
       testRunner: document.getElementById("test-runner"),
       chatWidget: document.getElementById("chat-widget"),
       workspaceTabs: document.querySelectorAll(".workspace-tab"),
       workspacePanels: document.querySelectorAll(".workspace-panel"),
     };
+
+    if (!this.app.config?.features?.collaboration && this.elements.chatToggleButton) {
+      this.elements.chatToggleButton.style.display = "none";
+    }
 
     // Vérifier que les éléments critiques existent
     if (!this.elements.editor) {
@@ -133,6 +138,9 @@ export class UIManager {
                   <button class="btn-secondary" id="btn-reset">
                     🔄 Réinitialiser
                   </button>
+                  <button class="btn-secondary" id="btn-chat-toggle">
+                    💬 Chat
+                  </button>
                 </div>
               </div>
 
@@ -171,6 +179,13 @@ export class UIManager {
     this.elements.resetButton.addEventListener("click", () => {
       this.resetCode();
     });
+
+    // Bouton Chat
+    if (this.elements.chatToggleButton) {
+      this.elements.chatToggleButton.addEventListener("click", () => {
+        this.toggleChatWidget();
+      });
+    }
 
     // Raccourcis clavier globaux
     document.addEventListener("editor:run", () => {
@@ -360,6 +375,14 @@ export class UIManager {
         });
       });
     });
+  }
+
+  toggleChatWidget() {
+    const widget = this.elements.chatWidget;
+    const btn = this.elements.chatToggleButton;
+    if (!widget || !btn) return;
+    const visible = widget.classList.toggle("visible");
+    btn.textContent = visible ? "❌ Fermer" : "💬 Chat";
   }
   showLoading(message = "Chargement...") {
     // Créer ou mettre à jour l'overlay de chargement

--- a/src/index.html
+++ b/src/index.html
@@ -59,6 +59,9 @@
                 <button class="btn-secondary" id="btn-reset">
                   🔄 Réinitialiser
                 </button>
+                <button class="btn-secondary" id="btn-chat-toggle">
+                  💬 Chat
+                </button>
               </div>
             </div>
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -751,11 +751,21 @@ body {
 
 /* Chat Widget */
 #chat-widget {
-  height: 200px;
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  width: 250px;
+  height: 250px;
   background: var(--bg-secondary);
-  border-top: 1px solid var(--border-color);
-  display: flex;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  display: none;
   flex-direction: column;
+  z-index: 40;
+}
+
+#chat-widget.visible {
+  display: flex;
 }
 
 .chat-status {


### PR DESCRIPTION
## Summary
- add Chat toggle button next to run and reset
- show/hide Chat widget via `toggleChatWidget`
- style Chat widget as floating panel
- document new behavior in README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68565b78a5708320b1bdb60cee52c6c6