### PR TITLE
Relocate output container

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -144,29 +144,29 @@ export class UIManager {
                 </div>
               </div>
 
-              <div class="output-container" id="output-container">
-  <div class="output-tabs">
-    <button class="output-tab active" data-panel="console">Console</button>
-    <button class="output-tab" data-panel="network">Réseau</button>
-    <button class="output-tab" data-panel="tests">Tests</button>
-  </div>
-  <div class="output-panels">
-    <div class="output-panel active" id="console-panel">
-      <div id="console"></div>
-    </div>
-    <div class="output-panel" id="network-panel">
-      <div id="network-monitor"></div>
-    </div>
-  <div class="output-panel" id="tests-panel">
-      <div id="test-runner"></div>
-    </div>
-  </div>
-</div>
               <div id="chat-widget"></div>
             </div>
           </div>
-        </section>
-      </main>
+          </section>
+          <div class="output-container" id="output-container">
+            <div class="output-tabs">
+              <button class="output-tab active" data-panel="console">Console</button>
+              <button class="output-tab" data-panel="network">Réseau</button>
+              <button class="output-tab" data-panel="tests">Tests</button>
+            </div>
+            <div class="output-panels">
+              <div class="output-panel active" id="console-panel">
+                <div id="console"></div>
+              </div>
+              <div class="output-panel" id="network-panel">
+                <div id="network-monitor"></div>
+              </div>
+              <div class="output-panel" id="tests-panel">
+                <div id="test-runner"></div>
+              </div>
+            </div>
+          </div>
+        </main>
     `;
   }
   setupEventListeners() {

--- a/src/index.html
+++ b/src/index.html
@@ -65,29 +65,29 @@
               </div>
             </div>
 
-            <div class="output-container" id="output-container">
-  <div class="output-tabs">
-    <button class="output-tab active" data-panel="console">Console</button>
-    <button class="output-tab" data-panel="network">Réseau</button>
-    <button class="output-tab" data-panel="tests">Tests</button>
-  </div>
-  <div class="output-panels">
-    <div class="output-panel active" id="console-panel">
-      <div id="console"></div>
-    </div>
-    <div class="output-panel" id="network-panel">
-      <div id="network-monitor"></div>
-    </div>
-  <div class="output-panel" id="tests-panel">
-      <div id="test-runner"></div>
-    </div>
-  </div>
-</div>
             <div id="chat-widget"></div>
           </div>
         </div>
-      </section>
-    </main>
+        </section>
+        <div class="output-container" id="output-container">
+          <div class="output-tabs">
+            <button class="output-tab active" data-panel="console">Console</button>
+            <button class="output-tab" data-panel="network">Réseau</button>
+            <button class="output-tab" data-panel="tests">Tests</button>
+          </div>
+          <div class="output-panels">
+            <div class="output-panel active" id="console-panel">
+              <div id="console"></div>
+            </div>
+            <div class="output-panel" id="network-panel">
+              <div id="network-monitor"></div>
+            </div>
+            <div class="output-panel" id="tests-panel">
+              <div id="test-runner"></div>
+            </div>
+          </div>
+        </div>
+      </main>
   </div>
   
   <script type="module" src="/src/main.js"></script>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -79,6 +79,7 @@ body {
 .app-main {
   flex: 1;
   display: flex;
+  flex-wrap: wrap;
   overflow: hidden;
 }
 
@@ -534,6 +535,14 @@ body {
 
 .network-row.error {
   background: rgba(245, 101, 101, 0.1);
+}
+
+/* Output Container positioned below workspace */
+.output-container {
+  flex-basis: 100%;
+  height: 200px;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-primary);
 }
 
 /* Tabs pour Console/Network */


### PR DESCRIPTION
## Summary
- move output container markup under workspace
- update UI template in `UIManager`
- tweak layout styles for full width console area
- allow wrapping rows in `.app-main`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685712ddb148832090f13593dd826d3e