### PR TITLE
Fix output panel visibility and resizing

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -81,6 +81,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   overflow: hidden;
+  position: relative;
 }
 
 .sidebar {
@@ -540,10 +541,17 @@ body {
 
 /* Output Container positioned below workspace */
 .output-container {
-  flex-basis: 100%;
-  height: 200px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 62px;
+  min-height: 62px;
+  resize: vertical;
+  overflow: auto;
   border-top: 1px solid var(--border-color);
   background: var(--bg-primary);
+  z-index: 40;
 }
 
 /* Tabs pour Console/Network */


### PR DESCRIPTION
## Summary
- set `.app-main` to position relative
- make output container fixed at the bottom and resizable

## Testing
- `npm run lint`
- `npx vitest` *(fails: Need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68579ccf347c8320b4756e825b989710