### PR TITLE
Add resizable output panel

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -30,6 +30,8 @@ export class UIManager {
       progressFill: document.getElementById("progress-fill"),
       testRunner: document.getElementById("test-runner"),
       chatWidget: document.getElementById("chat-widget"),
+      outputContainer: document.getElementById("output-container"),
+      outputResizer: document.getElementById("output-resizer"),
       workspaceTabs: document.querySelectorAll(".workspace-tab"),
       workspacePanels: document.querySelectorAll(".workspace-panel"),
     };
@@ -69,6 +71,7 @@ export class UIManager {
 
       // Gérer les onglets
       this.setupOutputTabs();
+      this.setupOutputResizer();
       this.setupWorkspaceTabs();
 
       // Configurer les événements
@@ -149,6 +152,7 @@ export class UIManager {
           </div>
           </section>
           <div class="output-container" id="output-container">
+            <div class="output-resizer" id="output-resizer"></div>
             <div class="output-tabs">
               <button class="output-tab active" data-panel="console">Console</button>
               <button class="output-tab" data-panel="network">Réseau</button>
@@ -354,6 +358,32 @@ export class UIManager {
           }
         });
       });
+    });
+  }
+
+  setupOutputResizer() {
+    const { outputResizer, outputContainer } = this.elements;
+    if (!outputResizer || !outputContainer) return;
+
+    const minHeight = 62;
+    let startY = 0;
+    let startHeight = 0;
+
+    const onMouseMove = (e) => {
+      const newHeight = Math.max(startHeight + (startY - e.clientY), minHeight);
+      outputContainer.style.height = `${newHeight}px`;
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+
+    outputResizer.addEventListener("mousedown", (e) => {
+      startY = e.clientY;
+      startHeight = outputContainer.offsetHeight;
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
     });
   }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -547,11 +547,17 @@ body {
   bottom: 0;
   height: 62px;
   min-height: 62px;
-  resize: vertical;
+  resize: none;
   overflow: auto;
   border-top: 1px solid var(--border-color);
   background: var(--bg-primary);
   z-index: 40;
+}
+
+.output-resizer {
+  height: 6px;
+  cursor: ns-resize;
+  background: var(--bg-secondary);
 }
 
 /* Tabs pour Console/Network */

--- a/tests/ui.resizer.test.js
+++ b/tests/ui.resizer.test.js
@@ -1,0 +1,32 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/components/Editor/Editor', () => ({ Editor: class {} }));
+vi.mock('@/components/Console/Console', () => ({ Console: class {} }));
+vi.mock('@/components/NetworkMonitor/NetworkMonitor', () => ({ NetworkMonitor: class {} }));
+vi.mock('@/components/TestRunner/TestRunner', () => ({ TestRunner: class {} }));
+vi.mock('@/components/ChatWidget/ChatWidget', () => ({ ChatWidget: class {} }));
+
+import { UIManager } from '@/core/UIManager';
+
+class DummyApp { constructor(){ this.config={}; this.modules={}; } }
+
+describe('UIManager output resizer', () => {
+  it('updates outputContainer height when dragged', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    const ui = new UIManager(new DummyApp());
+    ui.createUI();
+    ui.elements.outputContainer = document.getElementById('output-container');
+    ui.elements.outputResizer = document.getElementById('output-resizer');
+
+    Object.defineProperty(ui.elements.outputContainer, 'offsetHeight', { configurable: true, value: 100 });
+
+    ui.setupOutputResizer();
+
+    ui.elements.outputResizer.dispatchEvent(new MouseEvent('mousedown', { clientY: 200 }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 150 }));
+    document.dispatchEvent(new MouseEvent('mouseup'));
+
+    expect(ui.elements.outputContainer.style.height).toBe('150px');
+  });
+});


### PR DESCRIPTION
## Summary
- add draggable resizer in output panel markup
- wire up resizer behavior in `UIManager`
- style the resizer and adjust output container CSS
- test resizing functionality

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857ae773bfc8320bb3d330b9f22b4cf