### PR TITLE
Add collapsible sidebar over output panel

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -27,6 +27,8 @@ export class UIManager {
       runButton: document.getElementById("btn-run"),
       resetButton: document.getElementById("btn-reset"),
       chatToggleButton: document.getElementById("btn-chat-toggle"),
+      sidebarToggleButton: document.getElementById("btn-sidebar-toggle"),
+      sidebar: document.getElementById("sidebar"),
       progressFill: document.getElementById("progress-fill"),
       testRunner: document.getElementById("test-runner"),
       chatWidget: document.getElementById("chat-widget"),
@@ -36,7 +38,10 @@ export class UIManager {
       workspacePanels: document.querySelectorAll(".workspace-panel"),
     };
 
-    if (!this.app.config?.features?.collaboration && this.elements.chatToggleButton) {
+    if (
+      !this.app.config?.features?.collaboration &&
+      this.elements.chatToggleButton
+    ) {
       this.elements.chatToggleButton.style.display = "none";
     }
 
@@ -96,6 +101,7 @@ export class UIManager {
           <span class="header-tagline">Apprends à programmer</span>
         </div>
         <nav class="header-nav">
+          <button class="btn-icon" id="btn-sidebar-toggle" title="Menu">☰</button>
           <div id="course-selector" class="course-selector"></div>
           <button class="btn-icon" id="btn-settings" title="Paramètres">⚙️</button>
         </nav>
@@ -188,6 +194,12 @@ export class UIManager {
     if (this.elements.chatToggleButton) {
       this.elements.chatToggleButton.addEventListener("click", () => {
         this.toggleChatWidget();
+      });
+    }
+
+    if (this.elements.sidebarToggleButton) {
+      this.elements.sidebarToggleButton.addEventListener("click", () => {
+        this.toggleSidebar();
       });
     }
 
@@ -413,6 +425,16 @@ export class UIManager {
     if (!widget || !btn) return;
     const visible = widget.classList.toggle("visible");
     btn.textContent = visible ? "❌ Fermer" : "💬 Chat";
+  }
+
+  toggleSidebar() {
+    const sidebar = this.elements.sidebar;
+    if (!sidebar) return;
+    const collapsed = sidebar.classList.toggle("collapsed");
+    const btn = this.elements.sidebarToggleButton;
+    if (btn) {
+      btn.textContent = collapsed ? "☰" : "⮜";
+    }
   }
   showLoading(message = "Chargement...") {
     // Créer ou mettre à jour l'overlay de chargement

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,8 @@
         <span class="header-tagline">Apprends à programmer</span>
       </div>
       <nav class="header-nav">
-          <div id="course-selector" class="course-selector"></div>
+        <button class="btn-icon" id="btn-sidebar-toggle" title="Menu">☰</button>
+        <div id="course-selector" class="course-selector"></div>
         <button class="btn-icon" id="btn-settings" title="Paramètres">⚙️</button>
       </nav>
     </header>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -86,11 +86,21 @@ body {
 
 .sidebar {
   width: var(--sidebar-width);
+  flex: 0 0 var(--sidebar-width);
   background-color: var(--bg-secondary);
   border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  position: relative;
+  z-index: 50;
+  transition: width 0.3s ease, transform 0.3s ease;
+}
+
+.sidebar.collapsed {
+  width: 0;
+  flex-basis: 0;
+  transform: translateX(-100%);
 }
 
 .workspace {
@@ -276,13 +286,9 @@ body {
 @media (max-width: 768px) {
   .sidebar {
     position: absolute;
-    left: -100%;
-    z-index: 100;
-    transition: left 0.3s;
-  }
-
-  .sidebar.open {
+    top: 0;
     left: 0;
+    height: 100%;
   }
 
   .workspace {


### PR DESCRIPTION
## Summary
- make sidebar collapsible and overlay output panel
- add sidebar toggle button in header
- wire sidebar toggle logic in `UIManager`

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b30bb898832087a27b8f0221cfdf