### PR TITLE
Add UI element checks and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,13 @@ Configure its endpoint using the `registerServer` section of `public/config.json
 }
 ```
 
+
 `rtcConfig` is passed directly to `simple-peer` when creating the `RTCPeerConnection` and can be used to specify custom ICE servers.
+
+> **Note**
+> The **Exécuter**, **Réinitialiser**, **Chat** and sidebar toggle buttons are
+> inserted by the application at runtime. If the UI fails to initialize these
+> controls will be missing.
 
 ### Deploying the Worker
 

--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -50,6 +50,23 @@ export class UIManager {
       throw new Error("Editor element not found in DOM");
     }
 
+    const requiredControls = {
+      runButton: "btn-run",
+      resetButton: "btn-reset",
+      chatToggleButton: "btn-chat-toggle",
+      sidebarToggleButton: "btn-sidebar-toggle",
+    };
+
+    const missing = Object.entries(requiredControls)
+      .filter(([key]) => !this.elements[key])
+      .map(([, id]) => id);
+
+    if (missing.length) {
+      const message = `UI element(s) not found: ${missing.join(", ")}`;
+      this.showError(message);
+      throw new Error(message);
+    }
+
     try {
       // Initialiser l'éditeur
       this.editor = new Editor(this.elements.editor);

--- a/tests/ui.controls.test.js
+++ b/tests/ui.controls.test.js
@@ -1,0 +1,25 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/components/Editor/Editor', () => ({ Editor: class {} }));
+vi.mock('@/components/Console/Console', () => ({ Console: class {} }));
+vi.mock('@/components/NetworkMonitor/NetworkMonitor', () => ({ NetworkMonitor: class {} }));
+vi.mock('@/components/TestRunner/TestRunner', () => ({ TestRunner: class {} }));
+vi.mock('@/components/ChatWidget/ChatWidget', () => ({ ChatWidget: class {} }));
+
+import { UIManager } from '@/core/UIManager';
+
+class DummyApp { constructor(){ this.config = {}; this.modules = {}; } }
+
+describe('UIManager required controls', () => {
+  it('creates essential buttons', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    const ui = new UIManager(new DummyApp());
+    ui.createUI();
+
+    expect(document.getElementById('btn-run')).toBeTruthy();
+    expect(document.getElementById('btn-reset')).toBeTruthy();
+    expect(document.getElementById('btn-chat-toggle')).toBeTruthy();
+    expect(document.getElementById('btn-sidebar-toggle')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- verify control buttons exist during `UIManager.init`
- document dependency on successful UI initialization
- add test for `createUI` to assert button presence

## Testing
- `npm ci --silent`
- `CI=1 npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6857f7fd3d688320b855e70e9b34b112