### PR TITLE
Move sidebar toggle into lessons menu

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -118,14 +118,14 @@ export class UIManager {
           <span class="header-tagline">Apprends à programmer</span>
         </div>
         <nav class="header-nav">
-          <button class="btn-icon" id="btn-sidebar-toggle" title="Menu">☰</button>
           <div id="course-selector" class="course-selector"></div>
           <button class="btn-icon" id="btn-settings" title="Paramètres">⚙️</button>
         </nav>
       </header>
-      
+
       <main class="app-main">
         <aside class="sidebar" id="sidebar">
+          <button class="btn-icon sidebar-toggle" id="btn-sidebar-toggle" title="Menu">⮜</button>
           <div class="lessons-container">
             <h2>📚 Leçons</h2>
             <div id="lessons-list" class="lessons-list">
@@ -450,7 +450,7 @@ export class UIManager {
     const collapsed = sidebar.classList.toggle("collapsed");
     const btn = this.elements.sidebarToggleButton;
     if (btn) {
-      btn.textContent = collapsed ? "☰" : "⮜";
+      btn.textContent = collapsed ? "⮞" : "⮜";
     }
   }
   showLoading(message = "Chargement...") {

--- a/src/index.html
+++ b/src/index.html
@@ -14,14 +14,14 @@
         <span class="header-tagline">Apprends à programmer</span>
       </div>
       <nav class="header-nav">
-        <button class="btn-icon" id="btn-sidebar-toggle" title="Menu">☰</button>
         <div id="course-selector" class="course-selector"></div>
         <button class="btn-icon" id="btn-settings" title="Paramètres">⚙️</button>
       </nav>
     </header>
-    
+
     <main class="app-main">
       <aside class="sidebar" id="sidebar">
+        <button class="btn-icon sidebar-toggle" id="btn-sidebar-toggle" title="Menu">⮜</button>
         <div class="lessons-container">
           <h2>📚 Leçons</h2>
           <div id="lessons-list" class="lessons-list">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -97,10 +97,34 @@ body {
   transition: width 0.3s ease, transform 0.3s ease;
 }
 
+.sidebar-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 60;
+}
+
 .sidebar.collapsed {
-  width: 0;
-  flex-basis: 0;
-  transform: translateX(-100%);
+  width: 40px;
+  flex-basis: 40px;
+  transform: none;
+}
+
+.sidebar.collapsed .lessons-container,
+.sidebar.collapsed .progress-container {
+  display: none;
+}
+
+.sidebar.collapsed::after {
+  content: "Leçons";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-90deg);
+  transform-origin: center;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-size: 14px;
 }
 
 .workspace {


### PR DESCRIPTION
## Summary
- place the sidebar toggle button inside the lessons sidebar
- adjust UIManager HTML template to match
- update sidebar styles for collapsed mode with a thin strip labeled "Leçons"

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857fcca6bf0832096b6901f4bb7bc6f