### PR TITLE
Fix output container layout

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -173,7 +173,6 @@ export class UIManager {
               <div id="chat-widget"></div>
             </div>
           </div>
-          </section>
           <div class="output-container" id="output-container">
             <div class="output-resizer" id="output-resizer"></div>
             <div class="output-tabs">
@@ -193,6 +192,7 @@ export class UIManager {
               </div>
             </div>
           </div>
+          </section>
         </main>
     `;
   }

--- a/src/index.html
+++ b/src/index.html
@@ -69,7 +69,6 @@
             <div id="chat-widget"></div>
           </div>
         </div>
-        </section>
         <div class="output-container" id="output-container">
           <div class="output-tabs">
             <button class="output-tab active" data-panel="console">Console</button>
@@ -88,6 +87,7 @@
             </div>
           </div>
         </div>
+        </section>
       </main>
   </div>
   

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -130,7 +130,7 @@ body {
 .workspace {
   flex: 1;
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto 1fr auto;
   gap: 1px;
   background-color: var(--border-color);
   overflow: hidden;
@@ -316,7 +316,7 @@ body {
   }
 
   .workspace {
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto 1fr auto;
   }
 }
 
@@ -569,12 +569,8 @@ body {
   background: rgba(245, 101, 101, 0.1);
 }
 
-/* Output Container positioned below workspace */
+/* Output Container inside workspace */
 .output-container {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
   height: 62px;
   min-height: 62px;
   resize: none;


### PR DESCRIPTION
## Summary
- move output container inside the workspace section
- update UI template and CSS layout
- adjust grid rows for workspace

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685809b84b6c8320ac0faaca4557cfdf