### PR TITLE
Adjust workspace panel layout

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -394,7 +394,10 @@ export class UIManager {
     const { outputResizer, outputContainer } = this.elements;
     if (!outputResizer || !outputContainer) return;
 
-    const minHeight = 62;
+    const minHeight = parseInt(
+      window.getComputedStyle(outputContainer).minHeight,
+      10,
+    ) || 62;
     let startY = 0;
     let startHeight = 0;
 
@@ -403,16 +406,16 @@ export class UIManager {
       outputContainer.style.height = `${newHeight}px`;
     };
 
-    const onMouseUp = () => {
+    const stopDrag = () => {
       document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
+      document.removeEventListener("mouseup", stopDrag);
     };
 
     outputResizer.addEventListener("mousedown", (e) => {
       startY = e.clientY;
       startHeight = outputContainer.offsetHeight;
       document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", onMouseUp);
+      document.addEventListener("mouseup", stopDrag);
     });
   }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -614,7 +614,7 @@ body {
 
 .output-panels {
   position: relative;
-  height: calc(100% - 42px);
+  height: 100%;
 }
 
 .output-panel {
@@ -658,7 +658,7 @@ body {
 
 .workspace-panels {
   position: relative;
-  height: calc(100% - 42px);
+  height: 100%;
 }
 
 .workspace-panel {


### PR DESCRIPTION
## Summary
- fix workspace panel heights when output container is part of the grid
- compute resizer minimum height from CSS

## Testing
- `npm run build --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685816562fd48320ba2e848a302c4d69