### PR TITLE
Fix console cleanup and add success log support

### DIFF
--- a/src/components/Console/Console.js
+++ b/src/components/Console/Console.js
@@ -37,6 +37,10 @@ export class Console {
   info(...args) {
     this.addEntry('info', args);
   }
+
+  success(...args) {
+    this.addEntry('success', args);
+  }
   
   addEntry(type, args) {
     const entry = {

--- a/src/modules/python/PythonModule.js
+++ b/src/modules/python/PythonModule.js
@@ -93,20 +93,19 @@ import datetime
   async execute(code, context = {}) {
     const logs = [];
     const errors = [];
+    const originalLog = console.log;
+    const originalError = console.error;
     
     try {
       // Attendre que Pyodide soit chargé
       await this.loadingPromise;
       
       // Intercepter les sorties console
-      const originalLog = console.log;
-      const originalError = console.error;
-      
       console.log = (...args) => {
         logs.push({ type: 'log', args });
         originalLog.apply(console, args);
       };
-      
+
       console.error = (...args) => {
         logs.push({ type: 'error', args });
         originalError.apply(console, args);
@@ -142,8 +141,8 @@ import datetime
       });
       
       // Restaurer console
-      console.log = console.log;
-      console.error = console.error;
+      console.log = originalLog;
+      console.error = originalError;
       
       return {
         success: false,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -238,6 +238,10 @@ body {
   color: var(--color-warning);
 }
 
+.console-entry.console-success {
+  color: var(--color-success);
+}
+
 /* Buttons */
 .btn-primary,
 .btn-secondary,

--- a/tests/console.test.js
+++ b/tests/console.test.js
@@ -22,3 +22,16 @@ describe('Console.formatValue', () => {
     expect(formatValue('hello')).toBe('hello');
   });
 });
+
+describe('Console.success', () => {
+  it('adds a success log entry and element', () => {
+    document.body.innerHTML = '<div id="c"></div>';
+    const c = new Console(document.getElementById('c'));
+    c.success('yay');
+
+    expect(c.logs[0].type).toBe('success');
+    const elem = document.querySelector('.console-entry.console-success');
+    expect(elem).toBeTruthy();
+    expect(elem.textContent).toContain('yay');
+  });
+});


### PR DESCRIPTION
## Summary
- restore console log/error properly in Python module
- support success messages in console component
- style success output in the console
- test success console output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68584d72b70c83208b2db385423262b1