### PR TITLE
Adjust output panel default size

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -38,6 +38,9 @@ export class UIManager {
       workspacePanels: document.querySelectorAll(".workspace-panel"),
     };
 
+    // Définir la hauteur initiale de l'output
+    this.setInitialLayout();
+
     if (
       !this.app.config?.features?.collaboration &&
       this.elements.chatToggleButton
@@ -417,6 +420,19 @@ export class UIManager {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", stopDrag);
     });
+  }
+
+  setInitialLayout() {
+    const workspace = document.querySelector(".workspace");
+    const { outputContainer } = this.elements;
+    if (!workspace || !outputContainer) return;
+    const totalHeight = workspace.clientHeight;
+    const minHeight = parseInt(
+      window.getComputedStyle(outputContainer).minHeight,
+      10,
+    ) || 62;
+    const desired = Math.max(Math.floor(totalHeight / 3), minHeight);
+    outputContainer.style.height = `${desired}px`;
   }
 
   setupWorkspaceTabs() {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -575,7 +575,6 @@ body {
 
 /* Output Container inside workspace */
 .output-container {
-  height: 62px;
   min-height: 62px;
   resize: none;
   overflow: auto;


### PR DESCRIPTION
## Summary
- set initial layout so output container takes one-third of workspace height
- remove fixed height from `.output-container`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685998526d848320a92378f450789d60