### PR TITLE
Add manual resize flag handling

### DIFF
--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -11,6 +11,8 @@ export class UIManager {
     this.console = null;
     this.testRunner = null;
     this.elements = {};
+    // Indicates if the user manually changed the output height
+    this.outputManuallyResized = false;
   }
 
   async init() {
@@ -43,7 +45,9 @@ export class UIManager {
 
     // Ajuster l'output lors du redimensionnement de la fenêtre
     window.addEventListener("resize", () => {
-      this.setInitialLayout();
+      if (!this.outputManuallyResized) {
+        this.setInitialLayout();
+      }
     });
 
     if (
@@ -321,6 +325,11 @@ export class UIManager {
     }
   }
 
+  // Allow external callers to reset the manual resize flag
+  resetOutputResize() {
+    this.outputManuallyResized = false;
+  }
+
   showLesson(lesson) {
     if (!lesson) {
       this.elements.lessonInfo.innerHTML = `
@@ -415,6 +424,7 @@ export class UIManager {
     };
 
     const stopDrag = () => {
+      this.outputManuallyResized = true;
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", stopDrag);
     };
@@ -428,6 +438,7 @@ export class UIManager {
   }
 
   setInitialLayout() {
+    if (this.outputManuallyResized) return;
     requestAnimationFrame(() => {
       const workspace = document.querySelector(".workspace");
       const { outputContainer } = this.elements;

--- a/tests/ui.resizer.test.js
+++ b/tests/ui.resizer.test.js
@@ -29,4 +29,27 @@ describe('UIManager output resizer', () => {
 
     expect(ui.elements.outputContainer.style.height).toBe('150px');
   });
+
+  it('preserves manual height when setInitialLayout is called', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    const ui = new UIManager(new DummyApp());
+    ui.createUI();
+    ui.elements.outputContainer = document.getElementById('output-container');
+    ui.elements.outputResizer = document.getElementById('output-resizer');
+
+    Object.defineProperty(ui.elements.outputContainer, 'offsetHeight', { configurable: true, value: 100 });
+    ui.setupOutputResizer();
+
+    ui.elements.outputResizer.dispatchEvent(new MouseEvent('mousedown', { clientY: 200 }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 150 }));
+    document.dispatchEvent(new MouseEvent('mouseup'));
+
+    const workspace = document.querySelector('.workspace');
+    Object.defineProperty(workspace, 'clientHeight', { configurable: true, value: 600 });
+    global.requestAnimationFrame = (cb) => cb();
+
+    ui.setInitialLayout();
+
+    expect(ui.elements.outputContainer.style.height).toBe('150px');
+  });
 });


### PR DESCRIPTION
## Summary
- track when the output panel is manually resized
- keep output height unchanged after manual resize
- allow resetting the resize flag
- test resizer manual override persistence

## Testing
- `./node_modules/.bin/vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685afa6b961c83209cff16a6ae2a3482