### PR TITLE
Reset output resize when switching or resetting lessons

### DIFF
--- a/src/core/LessonManager.js
+++ b/src/core/LessonManager.js
@@ -240,7 +240,11 @@ async loadCourse(course) {
         </div>
       `
     });
-    
+
+    if (this.app.ui.resetOutputResize) {
+      this.app.ui.resetOutputResize();
+    }
+
     // Charger le code de démarrage
     this.app.ui.editor.setValue(this.currentExercise.starterCode);
     
@@ -366,6 +370,9 @@ ${exercise.difficulty}
     if (this.currentExercise) {
       this.app.ui.editor.setValue(this.currentExercise.starterCode);
       this.app.ui.console.info('Code réinitialisé');
+      if (this.app.ui.resetOutputResize) {
+        this.app.ui.resetOutputResize();
+      }
     }
   }
   


### PR DESCRIPTION
## Summary
- clear output resize flag when switching or resetting lessons

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_685b05430320832083a3ab63d610dfb5