### PR TITLE
Add mobile-responsive sidebar drawer and touch support

### DIFF
--- a/src/core/LessonManager.js
+++ b/src/core/LessonManager.js
@@ -189,6 +189,9 @@ async loadCourse(course) {
       
       // Afficher l'exercice
       this.displayExercise();
+
+      // Sur mobile, refermer le tiroir des leçons pour libérer l'espace
+      this.app.ui.closeMobileSidebar?.();
       
       // Activer le bon module
       const moduleType = exercise.language === 'web' ? 'web' : 'javascript';

--- a/src/core/UIManager.js
+++ b/src/core/UIManager.js
@@ -30,6 +30,7 @@ export class UIManager {
       resetButton: document.getElementById("btn-reset"),
       chatToggleButton: document.getElementById("btn-chat-toggle"),
       sidebarToggleButton: document.getElementById("btn-sidebar-toggle"),
+      mobileMenuButton: document.getElementById("btn-mobile-menu"),
       sidebar: document.getElementById("sidebar"),
       progressFill: document.getElementById("progress-fill"),
       testRunner: document.getElementById("test-runner"),
@@ -38,10 +39,18 @@ export class UIManager {
       outputResizer: document.getElementById("output-resizer"),
       workspaceTabs: document.querySelectorAll(".workspace-tab"),
       workspacePanels: document.querySelectorAll(".workspace-panel"),
+      sidebarBackdrop: document.getElementById("sidebar-backdrop"),
     };
+
+    this.mobileQuery = window.matchMedia("(max-width: 768px)");
 
     // Définir la hauteur initiale de l'output
     this.setInitialLayout();
+
+    // Sur mobile, le menu démarre fermé (tiroir hors-écran)
+    if (this.mobileQuery?.matches && this.elements.mobileMenuButton) {
+      this.elements.mobileMenuButton.textContent = "☰";
+    }
 
     // Ajuster l'output lors du redimensionnement de la fenêtre
     window.addEventListener("resize", () => {
@@ -125,6 +134,7 @@ export class UIManager {
     // Remplacer le contenu de chargement par l'interface
     app.innerHTML = `
       <header class="app-header">
+        <button class="btn-icon mobile-menu-toggle" id="btn-mobile-menu" title="Menu">☰</button>
         <div class="header-brand">
           <h1>🚀 CodePlay</h1>
           <span class="header-tagline">Apprends à programmer</span>
@@ -151,7 +161,8 @@ export class UIManager {
             <span class="progress-text">0% complété</span>
           </div>
         </aside>
-        
+        <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
+
         <section class="workspace">
           <div class="workspace-tabs" role="tablist">
             <button class="workspace-tab active" data-panel="lesson" role="tab" aria-controls="lesson-panel">Énoncé</button>
@@ -229,6 +240,18 @@ export class UIManager {
     if (this.elements.sidebarToggleButton) {
       this.elements.sidebarToggleButton.addEventListener("click", () => {
         this.toggleSidebar();
+      });
+    }
+
+    if (this.elements.mobileMenuButton) {
+      this.elements.mobileMenuButton.addEventListener("click", () => {
+        this.toggleSidebar();
+      });
+    }
+
+    if (this.elements.sidebarBackdrop) {
+      this.elements.sidebarBackdrop.addEventListener("click", () => {
+        this.closeMobileSidebar();
       });
     }
 
@@ -435,6 +458,30 @@ export class UIManager {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", stopDrag);
     });
+
+    const onTouchMove = (e) => {
+      const touchY = e.touches[0].clientY;
+      const newHeight = Math.max(startHeight + (startY - touchY), minHeight);
+      outputContainer.style.height = `${newHeight}px`;
+      e.preventDefault();
+    };
+
+    const stopTouchDrag = () => {
+      this.outputManuallyResized = true;
+      document.removeEventListener("touchmove", onTouchMove);
+      document.removeEventListener("touchend", stopTouchDrag);
+    };
+
+    outputResizer.addEventListener(
+      "touchstart",
+      (e) => {
+        startY = e.touches[0].clientY;
+        startHeight = outputContainer.offsetHeight;
+        document.addEventListener("touchmove", onTouchMove, { passive: false });
+        document.addEventListener("touchend", stopTouchDrag);
+      },
+      { passive: true },
+    );
   }
 
   setInitialLayout() {
@@ -484,10 +531,30 @@ export class UIManager {
   toggleSidebar() {
     const sidebar = this.elements.sidebar;
     if (!sidebar) return;
+
+    if (this.mobileQuery?.matches) {
+      const open = sidebar.classList.toggle("mobile-open");
+      this.elements.sidebarBackdrop?.classList.toggle("visible", open);
+      if (this.elements.mobileMenuButton) {
+        this.elements.mobileMenuButton.textContent = open ? "✕" : "☰";
+      }
+      return;
+    }
+
     const collapsed = sidebar.classList.toggle("collapsed");
     const btn = this.elements.sidebarToggleButton;
     if (btn) {
       btn.textContent = collapsed ? "⮞" : "⮜";
+    }
+  }
+
+  closeMobileSidebar() {
+    const sidebar = this.elements.sidebar;
+    if (!sidebar) return;
+    sidebar.classList.remove("mobile-open");
+    this.elements.sidebarBackdrop?.classList.remove("visible");
+    if (this.elements.mobileMenuButton) {
+      this.elements.mobileMenuButton.textContent = "☰";
     }
   }
   showLoading(message = "Chargement...") {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -53,6 +53,10 @@ body {
   padding: 0 20px;
 }
 
+.mobile-menu-toggle {
+  display: none;
+}
+
 .header-brand {
   display: flex;
   align-items: baseline;
@@ -95,6 +99,10 @@ body {
   position: relative;
   z-index: 50;
   transition: width 0.3s ease, transform 0.3s ease;
+}
+
+.sidebar-backdrop {
+  display: none;
 }
 
 .sidebar-toggle {
@@ -312,15 +320,144 @@ body {
 
 /* Responsive */
 @media (max-width: 768px) {
+  html,
+  body {
+    overscroll-behavior: none;
+  }
+
+  .app-header {
+    height: auto;
+    flex-wrap: wrap;
+    padding: 10px 12px;
+    gap: 8px;
+  }
+
+  .header-brand h1 {
+    font-size: 18px;
+  }
+
+  .header-tagline {
+    display: none;
+  }
+
+  .mobile-menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    order: -1;
+  }
+
+  .header-nav {
+    gap: 10px;
+  }
+
+  .app-main {
+    flex-direction: column;
+  }
+
+  /* Le menu des leçons devient un tiroir hors-écran */
   .sidebar {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     height: 100%;
+    width: 85%;
+    max-width: 320px;
+    flex-basis: auto;
+    transform: translateX(-100%);
+    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.4);
+    z-index: 110;
+  }
+
+  .sidebar.collapsed {
+    width: 85%;
+    max-width: 320px;
+  }
+
+  .sidebar.collapsed::after {
+    content: none;
+  }
+
+  .sidebar.mobile-open {
+    transform: translateX(0);
+  }
+
+  .sidebar-toggle {
+    display: none;
+  }
+
+  .sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 100;
+    display: none;
+  }
+
+  .sidebar-backdrop.visible {
+    display: block;
   }
 
   .workspace {
     grid-template-rows: auto 1fr auto;
+    width: 100%;
+  }
+
+  .workspace-tabs,
+  .output-tabs,
+  .file-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .workspace-tab,
+  .output-tab {
+    flex-shrink: 0;
+    padding: 10px 14px;
+  }
+
+  /* Boutons et zones tactiles agrandies */
+  .btn-primary,
+  .btn-secondary,
+  .btn-icon {
+    min-height: 44px;
+    padding: 10px 14px;
+  }
+
+  /* La barre d'actions flottante devient une barre d'outils ancrée */
+  .floating-actions {
+    position: static;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 10px;
+    background-color: var(--bg-secondary);
+    border-top: 1px solid var(--border-color);
+  }
+
+  .editor-container {
+    height: auto;
+    min-height: 0;
+  }
+
+  .editor {
+    min-height: 200px;
+  }
+
+  .output-container {
+    max-height: 45vh;
+  }
+
+  .lessons-container,
+  .lesson-info,
+  .progress-container {
+    padding: 14px;
+  }
+
+  #chat-widget {
+    left: 12px;
+    right: 12px;
+    width: auto;
+    bottom: 70px;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR implements comprehensive mobile responsiveness for the CodePlay application, transforming the sidebar into an off-screen drawer menu on mobile devices and adding touch support for the output resizer.

## Key Changes

**Mobile Navigation:**
- Added a mobile menu toggle button (hamburger icon) that appears only on screens ≤768px
- Converted the sidebar from a collapsible panel to a fixed off-screen drawer that slides in from the left
- Implemented a semi-transparent backdrop that appears when the drawer is open and closes it when clicked
- The drawer automatically closes when a lesson is selected to free up screen space

**Layout Adjustments for Mobile:**
- Adjusted header layout with reduced padding and font sizes
- Hidden the header tagline on mobile
- Changed main layout from side-by-side to stacked (flex-direction: column)
- Made workspace tabs horizontally scrollable with touch support
- Increased button touch targets to minimum 44px height for better mobile usability
- Converted floating action bar to a static anchored toolbar
- Repositioned chat widget to avoid overlap with toolbar
- Added `overscroll-behavior: none` to prevent unwanted scroll bounce

**Touch Interaction Support:**
- Added touch event handlers for the output resizer (previously only supported mouse dragging)
- Implemented `touchstart`, `touchmove`, and `touchend` listeners with proper passive event handling
- Maintains the same resize behavior as mouse interactions

**UI Manager Updates:**
- Added `mobileMenuButton` and `sidebarBackdrop` element references
- Implemented media query detection for responsive behavior
- Added `toggleSidebar()` logic that differentiates between mobile drawer and desktop collapse modes
- Added `closeMobileSidebar()` method for programmatic drawer closing

## Implementation Details
- Mobile detection uses `window.matchMedia("(max-width: 768px)")` for consistent breakpoint handling
- Sidebar uses CSS `transform: translateX(-100%)` for smooth off-screen positioning
- Z-index layering: sidebar (110) > backdrop (100) ensures proper stacking
- Touch events use `{ passive: false }` on `touchmove` to allow `preventDefault()` for smooth dragging

https://claude.ai/code/session_01TSoGHU3AzsySXELTX6nqtd